### PR TITLE
[Refactor/#167] formatter import* 미적용

### DIFF
--- a/docs/back-end/ibas_intellij_formatting.xml
+++ b/docs/back-end/ibas_intellij_formatting.xml
@@ -15,8 +15,8 @@
 
   <!-- Line Separator and Import Settings -->
   <option name="LINE_SEPARATOR" value="&#10;" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
 
   <!-- JavaDoc Comments -->
   <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />


### PR DESCRIPTION
[import 시 * 와일드카드 사용여부 논의](https://github.com/InhaBas/Inhabas.com-api/issues/187)

- 참조문서
[Google Style Guide: 3.3.1 No wildcard imports](https://google.github.io/styleguide/javaguide.html#s3.3-import-statements:~:text=3.3.1%20No%20wildcard%20imports)
[Stack Overflow: Why is using a wild card with a Java import statement bad?](https://stackoverflow.com/questions/147454/why-is-using-a-wild-card-with-a-java-import-statement-bad)

에 따른 formatting 코드 컨벤션 변경