### PR TITLE
[feat/#229] fix: 회계내역 관련 fetch api의 useEffect 의존성 배열에 accessToken 추가

### DIFF
--- a/src/Components/Common/Modal/ModalBankHistoryDetail.tsx
+++ b/src/Components/Common/Modal/ModalBankHistoryDetail.tsx
@@ -7,6 +7,7 @@ import { theme } from "../../../styles/theme";
 import useFetch from "../../../Hooks/useFetch";
 
 import { modalInfo, modalOpen } from "../../../Recoil/frontState";
+import { tokenAccess } from "../../../Recoil/backState";
 
 import { Div, FlexDiv } from "../../../styles/assets/Div";
 import { H2 } from "../../../styles/assets/H";
@@ -21,11 +22,14 @@ const ModalBankHistoryDetail = () => {
     };
 
     const modalInfos = useRecoilValue(modalInfo);
+    const accessToken = useRecoilValue(tokenAccess);
+
     const [data, fetchData] = useFetch();
+    
     useEffect(() => {
         fetchData(`/budget/history/${modalInfos?.content}`, "GET", "token");
         console.log(data)
-    }, []);
+    }, [accessToken]);
 
     return (
         <FlexDiv

--- a/src/Components/Common/Modal/ModalUpdateBankHistory.tsx
+++ b/src/Components/Common/Modal/ModalUpdateBankHistory.tsx
@@ -6,6 +6,7 @@ import { theme } from "../../../styles/theme";
 import useFetch from "../../../Hooks/useFetch";
 
 import { modalOpen, selectedStudentInfos, selectedFile, modalInfo } from "../../../Recoil/frontState";
+import { tokenAccess } from "../../../Recoil/backState";
 
 import Button from "../../../styles/assets/Button";
 import { Div, FlexDiv } from "../../../styles/assets/Div";
@@ -23,6 +24,7 @@ const ModalUpdateBankHistory = () => {
     const [historyInfo, fetchGetHistory] = useFetch();
 
     const modalContent = useRecoilValue(modalInfo)!;
+    const accessToken = useRecoilValue(tokenAccess);
 
     const [_update, fetchUpdateHistory] = useFetch();
 
@@ -41,7 +43,7 @@ const ModalUpdateBankHistory = () => {
 
     useEffect(() => {
         fetchGetHistory(`/budget/history/${modalContent.content}`, 'GET', "token")
-    }, [])
+    }, [accessToken])
 
     useEffect(() => {
         setSelectedInfos(prev => ({

--- a/src/Components/Page/IBAS/Bank/Bank.tsx
+++ b/src/Components/Page/IBAS/Bank/Bank.tsx
@@ -7,8 +7,8 @@ import Pagination from "../../../Common/Pagination";
 
 import useFetch from "../../../../Hooks/useFetch";
 
-import { bankHistoryInfo, totalPageInfo, bankBalanceInfo, bankYearsInfo } from "../../../../Recoil/backState";
-import { useRecoilState } from "recoil";
+import { bankHistoryInfo, totalPageInfo, bankBalanceInfo, bankYearsInfo, tokenAccess } from "../../../../Recoil/backState";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { useEffect, useState } from "react";
 
 import { modalInfo } from "../../../../Recoil/frontState";
@@ -35,6 +35,7 @@ const Bank = () => {
     const [bankHistory, setBankHistory] = useRecoilState(bankHistoryInfo);
     const [bankBalance, setBankBalance] = useRecoilState(bankBalanceInfo);
     const [totalPage, setTotalPage] = useRecoilState(totalPageInfo);
+    const accessToken = useRecoilValue(tokenAccess);
 
     const [bankYearsData, fetchBankYearsData] = useFetch();
     const [bankYears, setBankYears] = useRecoilState(bankYearsInfo);
@@ -48,7 +49,7 @@ const Bank = () => {
     // 연도 데이터 패치
     useEffect(() => {
         fetchBankYearsData('/budget/histories/years', 'GET');
-    }, [])
+    }, [accessToken])
 
     // 연도 데이터 패치 후 bankYears에 매핑
     useEffect(() => {
@@ -62,7 +63,7 @@ const Bank = () => {
         if (bankYears && bankYears[0]) {
             fetchBankHistoryData(`/budget/histories?year=${selectedYear}&page=${'0'}&size=${'15'}`, "GET", "token")
         }
-    }, [bankYears, selectedYear])
+    }, [bankYears, selectedYear, accessToken])
 
     useEffect(() => {
         if (bankHistoryData) {


### PR DESCRIPTION
- 회계내역 페이지 내에서 회계내역을 못 불러오는 문제 발생
- Bank, ModalBankHistoryDetail, ModalUpdateBankHisotry의 fetch를 사용하는 useEffect 의존성 배열에 accessToken 변수 추가하여 해결