### PR TITLE
[fix/#264] fix: useFetch 결과 응답 바디가 없을 때의 로직 수정

### DIFF
--- a/src/Components/Page/Member/Signup.tsx
+++ b/src/Components/Page/Member/Signup.tsx
@@ -228,14 +228,16 @@ const Signup = () => {
 
     /* 학생용 signUp api 가 잘 POST 된 경우 */
     useEffect(() => {
-        if (postData === "noContents") {
+        // if (postData === "noContents") {
+        if (postData) {
             navigate("/signup/question");
         }
     }, [postData]);
 
     /* 교수용 signUp api 가 잘 POST 된 경우 */
     useEffect(() => {
-        if (proPostData === "noContents") {
+        // if (proPostData === "noContents") {
+        if (proPostData) {
             setReload(true);
             navigate("/");
         }

--- a/src/Components/Page/Member/SignupQuestion.tsx
+++ b/src/Components/Page/Member/SignupQuestion.tsx
@@ -109,7 +109,8 @@ const SignupQuestion = () => {
     토큰에 저장되어 있는 정보가 달라지므로, 회원 가입 후에는 항상 reload 해주어야 함
      */
     useEffect(() => {
-        if (putData === "noContents") {
+        // if (putData === "noContents") {
+        if (putData) {
             alert("회원가입을 축하합니다!");
             setReload(true);
             navigate("/");
@@ -120,7 +121,8 @@ const SignupQuestion = () => {
     답변 저장에 성공한 경우
     */
     useEffect(() => {
-        if (postData === "noContents") {
+        // if (postData === "noContents") {
+        if (postData) {
             alert("답변이 저장되었습니다.");
         }
     }, [postData]);

--- a/src/Hooks/useFetch.tsx
+++ b/src/Hooks/useFetch.tsx
@@ -78,7 +78,7 @@ const useFetch = (): [
 
                     if (res.ok) {
                         if (res.status === 204 || res.headers.get("content-length") === "0" || res.body === null) {
-                            setData("noContents");
+                            setData((new Date()).toLocaleString())
                         } else {
                             result = await res.json();
                             console.log({ ...result });
@@ -113,7 +113,7 @@ const useFetch = (): [
 
                 if (res.ok) {
                     if (res.status === 204 || res.headers.get("content-length") === "0" || res.body === null) {
-                        setData("noContents");
+                        setData((new Date()).toLocaleString())
                     } else {
                         result = await res.json();
                         console.log({ ...result });


### PR DESCRIPTION
- useFetch: 기존 noContents를 할당 => Date 객체를 통한 현재 시간을 할당
- Signup: useEffect 안 noContents 조건 로직 수정
- SignupQuestion: useEffect 안 noContents 조건 로직 수정
- Update를 연속 2번 시도할 때 noContents라는 문자열이 변화하지 않아 useEffect가 작동되지 않는 문제를 해결하기 위함
- 이전의 회원 가입 파일 안의 조건 코드는 주석으로 남겨둠 => 추후에 문제가 생길 것을 대비