### PR TITLE
Feat/#383

### DIFF
--- a/src/Components/Common/DragNDrop.tsx
+++ b/src/Components/Common/DragNDrop.tsx
@@ -98,6 +98,12 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                     case "usage":
                         titleId = 22;
                         break;
+                    case "contest":
+                        titleId = 18;
+                        break;
+                    case "activity":
+                        titleId = 19;
+                        break;
                     default: // 혹은 다른 값으로 설정
                         // pathName1이 위의 case에 일치하지 않는 경우에 대한 처리
                         titleId = 0;
@@ -122,16 +128,6 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                     titleId = 14;
                 }
                 break;
-
-            case "contest":
-                switch (pathName2) {
-                    case "":
-                        titleId = 18;
-                        break;
-                    case "activity":
-                        titleId = 19;
-                        break;
-                }
         }
         return titleId;
     };

--- a/src/Components/Common/HeaderNav.tsx
+++ b/src/Components/Common/HeaderNav.tsx
@@ -102,6 +102,12 @@ const HeaderNav = () => {
                     case "usage":
                         titleId = 22;
                         break;
+                    case "contest":
+                        titleId = 18;
+                        break;
+                    case "activity":
+                        titleId = 19;
+                        break;
                     default: // 혹은 다른 값으로 설정
                         // pathName1이 위의 case에 일치하지 않는 경우에 대한 처리
                         titleId = 0;
@@ -126,16 +132,6 @@ const HeaderNav = () => {
                     titleId = 14;
                 }
                 break;
-
-            case "contest":
-                switch (pathName2) {
-                    case "":
-                        titleId = 18;
-                        break;
-                    case "activity":
-                        titleId = 19;
-                        break;
-                }
         }
         return titleId;
     };
@@ -146,7 +142,7 @@ const HeaderNav = () => {
         ["lecture", "lecture", "lecture", "lecture"],
         ["bank/support", "bank"],
         ["board/alpha", "board/beta"],
-        ["contest", "contest/activity"],
+        ["board/contest", "board/activity"],
         ["scholarship", "board/sponsor", "board/usage"],
     ];
 
@@ -155,7 +151,7 @@ const HeaderNav = () => {
     };
 
     const menuClickEvent = (url: string, givenName: string, givenDescription: string) => {
-        if (['contest', 'contest/activity', 'lecture', 'honor', 'activity'].includes(url)) {
+        if (['lecture', 'honor', 'activity'].includes(url)) {
             alert('사용할 수 없는 기능입니다.')
             return
         }
@@ -179,6 +175,7 @@ const HeaderNav = () => {
 
     useEffect(() => {
         const id = titleInfo(pathNameInfo[0], pathNameInfo[1]);
+        console.log(id, 'id')
         setCurrentMenuId(id);
         fetchData("/menus", "GET");
     }, []);

--- a/src/Components/Common/HeaderTitle.tsx
+++ b/src/Components/Common/HeaderTitle.tsx
@@ -40,7 +40,7 @@ const HeaderTitle = () => {
     let titleId = 0;
 
     useEffect(() => {
-        if ((isNotLogin && (!['opensource', 'sponsor', 'usage']?.includes(pathNameInfo[1]) && 'contest' !== pathNameInfo[0]))) {
+        if (isNotLogin && !['opensource', 'sponsor', 'usage', 'contest', 'activity']?.includes(pathNameInfo[1])) {
             alert('로그인을 해주세요');
             navigate('/');
         }
@@ -91,6 +91,12 @@ const HeaderTitle = () => {
                     case "usage":
                         titleId = 22;
                         break;
+                    case "contest":
+                        titleId = 18;
+                        break;
+                    case "activity":
+                        titleId = 19;
+                        break;
                     default: // 혹은 다른 값으로 설정
                         // pathName1이 위의 case에 일치하지 않는 경우에 대한 처리
                         titleId = 0;
@@ -115,16 +121,6 @@ const HeaderTitle = () => {
                     titleId = 14;
                 }
                 break;
-
-            case "contest":
-                switch (pathName2) {
-                    case undefined:
-                        titleId = 18;
-                        break;
-                    case "activity":
-                        titleId = 19;
-                        break;
-                }
         }
         return titleId;
     };

--- a/src/Components/Component/Board/BoardNavigate.tsx
+++ b/src/Components/Component/Board/BoardNavigate.tsx
@@ -27,6 +27,8 @@ const BoardNavigate = () => {
     useEffect(() => {
         if (url === "alpha" || url === "beta") {
             fetchMenuData("/project/count", "GET", "token");
+        } else if (url === "contest" || url === "activity") {
+            fetchMenuData("/contest/count", "GET", "token");
         } else {
             fetchMenuData("/board/count", "GET", "token");
         }

--- a/src/Components/Component/Board/BoardSearch.tsx
+++ b/src/Components/Component/Board/BoardSearch.tsx
@@ -39,6 +39,10 @@ const BoardSearch = () => {
         fetchUrl = "/scholarship/usage";
     } else if (url === "opensource") {
         fetchUrl = "/board/storage";
+    } else if (url === "contest") {
+        fetchUrl = "/contest/contest";
+    } else if (url === "activity") {
+        fetchUrl = "/contest/activity";
     } else {
         fetchUrl = `/board/${url}`;
     }
@@ -46,12 +50,12 @@ const BoardSearch = () => {
     const searchEvent = () => {
         // 토큰 없이 fetch
         if (inputRef.current !== null && inputRef.current.value !== null) {
-            if (['usage', 'sponsor'].includes(url)) {
+            if (['usage', 'sponsor', 'contest', 'activity'].includes(url)) {
                 fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=15`, "GET");
             } else {
                 fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=15`, "GET", "token");
             }
-        } 
+        }
     };
 
     useEffect(() => {
@@ -65,7 +69,6 @@ const BoardSearch = () => {
                 isPinned: item.isPinned,
             }));
             const pinnedContents = boardListData.pinnedData?.map((item: boardListInterface, idx: number) => ({
-                // number: idx + 1,
                 id: item.id,
                 title: item.title,
                 writerName: item.writerName,

--- a/src/Components/Component/Contest/ContestInfo.tsx
+++ b/src/Components/Component/Contest/ContestInfo.tsx
@@ -1,0 +1,80 @@
+import { Div, FlexDiv } from "../../../styles/assets/Div";
+import P from "../../../styles/assets/P";
+import Img from "../../../styles/assets/Img";
+import Button from "../../../styles/assets/Button";
+import { useNavigate } from "react-router-dom";
+
+const ContestInfo = ({ info }: {info: any}) => {
+
+    const navigate = useNavigate();
+
+    const data = {
+        thumbnailUrl: info?.thumbnail?.url,
+        dateEnd: info?.dateContestEnd?.split('T')[0],
+        dateStart: info?.dateContestStart?.split('T')[0],
+        endMonth: info?.dateContestEnd?.split('T')[0]?.split('-')[1],
+        endDay: info?.dateContestEnd?.split('T')[0]?.split('-')[2],
+        title: info?.title,
+        topic: info?.topic,
+        id: info?.id,
+    }
+    return (
+        <>
+            <Div width="100%" height="600px" $border="1px solid" $borderColor="border">
+                    {/* 사진 영역 */}
+                    <Div width="100%" height="70%" $border="1px solid" $borderColor="border">
+                        <Button width="100%" height="100%" onClick={() => navigate(`/board/contest/detail/${data?.id}`)}>
+                            <Img src={data?.thumbnailUrl} width='100%' height='100%' />
+                        </Button>
+                    </Div>
+                    {/* 내용 영역 */}
+                    <Div height="30%"width="100%">
+                        {/* 윗 내용 */}
+                        <FlexDiv height="70%" width="100%" $padding="20px" $border="1px solid" $borderColor="border">
+                            {/* 마감 날짜 */}
+                            <Div width="30%" height="100%" $border="1px solid" $borderColor="border">
+                                <FlexDiv width="100%">
+                                    <Div>
+                                        <P color="blue" fontWeight={600}>{data?.endMonth}</P>
+                                    </Div>
+                                </FlexDiv>
+                                <FlexDiv width="100%" $margin="10px 0 0 0">
+                                    <Div>
+                                        <P color="primary" fontSize="lg" fontWeight={800}>{data?.endDay}</P>
+                                    </Div>
+                                </FlexDiv>
+                                <FlexDiv width="100%">
+                                    <Div>
+                                        <P>마감</P>
+                                    </Div>
+                                </FlexDiv>
+                            </Div>
+                            {/* 공모전 정보 */}
+                            <Div width="70%" height="100%" $border="1px solid" $borderColor="border">
+                                <Div width="100%">
+                                    <P fontSize="md" fontWeight={700}>{data?.title}</P>
+                                </Div>
+                                <Div>
+                                    <P>{data?.topic}</P>
+                                </Div>
+                                <Div>
+                                    <P>마감</P>
+                                </Div>
+                            </Div>
+                        </FlexDiv>
+                        {/* 아랫 내용 */}
+                        <FlexDiv height="30%" width="100%" $border="1px solid" $borderColor="border" $justifycontent="flex-start" $padding="15px">
+                            <Div>
+                                <P>기간</P>
+                            </Div>
+                            <Div $margin="0 0 0 15px">
+                                <P>{`${data?.dateStart}~${data?.dateEnd}`}</P>
+                            </Div>
+                        </FlexDiv>
+                    </Div>
+                </Div>
+        </>
+    )
+}
+
+export default ContestInfo;

--- a/src/Components/Page/Board/BoardList.tsx
+++ b/src/Components/Page/Board/BoardList.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import useFetch from "../../../Hooks/useFetch";
 
-import { boardListDataInfo, boardListPinnedDataInfo, tokenAccess, totalPageInfo } from "../../../Recoil/backState";
+import { boardListDataInfo, boardListPinnedDataInfo, tokenAccess, totalPageInfo, contestListDataInfo } from "../../../Recoil/backState";
 
 import { boardListInterface } from "../../../Types/TypeBoard";
 
@@ -22,6 +22,7 @@ import NavigateTable from "../../Common/NavigateTable";
 import Pagination from "../../Common/Pagination";
 import BoardNavigate from "../../Component/Board/BoardNavigate";
 import BoardSearch from "../../Component/Board/BoardSearch";
+import Contest from "../IBAS/Contest/Contest";
 
 const StickyDiv = styled(Div)`
     position: sticky;
@@ -42,6 +43,7 @@ const BoardList = () => {
     const [boardPinnedList, setBoardPinnedList] = useRecoilState(boardListPinnedDataInfo);
     const [boardListData, fetchBoardListData] = useFetch();
     const [totalPage, setTotalPage] = useRecoilState(totalPageInfo);
+    const [contestListData, setContestListData] = useRecoilState(contestListDataInfo);
     const [isLoading, setIsLoading] = useState(true);
     const { isAuthorizedOverSecretary, isAuthorizedOverDeactivate, isSecretary, isAuthorizedOverBasic } =
         GetRoleAuthorization();
@@ -57,6 +59,10 @@ const BoardList = () => {
         fetchUrl = "/scholarship/usage";
     } else if (url === "opensource") {
         fetchUrl = "/board/storage";
+    } else if (url === "contest") {
+        fetchUrl = "/contest/contest";
+    } else if (url === "activity") {
+        fetchUrl = "/contest/activity";
     } else {
         fetchUrl = `/board/${url}`;
     }
@@ -84,33 +90,41 @@ const BoardList = () => {
         setIsLoading(true);
         if (["opensource", "usage", "sponsor"].includes(url)) {
             fetchBoardListData(`${fetchUrl}`, "GET");
+        } else if (["contest", "activity"].includes(url)) {
+            console.log('패치')
+            fetchBoardListData(`${fetchUrl}`, "GET", "token");
         } else {
             fetchBoardListData(`${fetchUrl}`, "GET", "token");
         }
     }, [url, access])
 
     useEffect(() => {
-        if (boardListData) {
-            const contents = boardListData.data.map((item: boardListInterface, idx: number) => ({
-                number: boardListData.pageInfo.pageNumber * boardListData.pageInfo.pageSize + idx + 1,
-                id: item.id,
-                title: item.title,
-                writerName: item.writerName,
-                dateCreated: formatDateDay({ date: item.dateCreated }),
-                isPinned: item.isPinned,
-            }));
-            const pinnedContents = boardListData.pinnedData?.map((item: boardListInterface, idx: number) => ({
-                // number: idx + 1,
-                id: item.id,
-                title: item.title,
-                writerName: item.writerName,
-                dateCreated: formatDateDay({ date: item.dateCreated }),
-                isPinned: item.isPinned,
-            }));
-            setBoardPinnedList(pinnedContents);
-            setBoardList(contents);
-            setTotalPage(boardListData.pageInfo.totalPages);
+        if (["contest", "activity"].includes(url)) {
             setIsLoading(false);
+            // console.log(boardListData)
+            // setContestListData();
+        } else {
+            if (boardListData) {
+                const contents = boardListData.data.map((item: boardListInterface, idx: number) => ({
+                    number: boardListData.pageInfo.pageNumber * boardListData.pageInfo.pageSize + idx + 1,
+                    id: item.id,
+                    title: item.title,
+                    writerName: item.writerName,
+                    dateCreated: formatDateDay({ date: item.dateCreated }),
+                    isPinned: item.isPinned,
+                }));
+                const pinnedContents = boardListData.pinnedData?.map((item: boardListInterface, idx: number) => ({
+                    id: item.id,
+                    title: item.title,
+                    writerName: item.writerName,
+                    dateCreated: formatDateDay({ date: item.dateCreated }),
+                    isPinned: item.isPinned,
+                }));
+                setBoardPinnedList(pinnedContents);
+                setBoardList(contents);
+                setTotalPage(boardListData.pageInfo.totalPages);
+                setIsLoading(false);
+            }
         }
     }, [boardListData]);
 
@@ -134,13 +148,15 @@ const BoardList = () => {
                     </StickyDiv>
                     <Div $padding="0 15px">
                         <Suspense fallback={<Img src="/images/loading.svg" />}>
-                            <NavigateTable
-                                width={widthList}
-                                header={headerInfo}
-                                contents={boardList}
-                                pinnedContents={boardPinnedList}
-                                url="detail"
-                            />
+                            { ["contest", "activity"].includes(url) ? <Contest /> :
+                                <NavigateTable
+                                    width={widthList}
+                                    header={headerInfo}
+                                    contents={boardList}
+                                    pinnedContents={boardPinnedList}
+                                    url="detail"
+                                />
+                            }
                         </Suspense>
                         {checkWritingAuthorization() && (
                             <FlexDiv width="100%" $justifycontent="end" $margin="20px 0 0 0">
@@ -151,7 +167,7 @@ const BoardList = () => {
                                     $padding="12px 15px"
                                     $borderRadius={30}
                                     $HBackgroundColor="bgColorHo"
-                                    onClick={() => navigate(`/board/${url}/create`)}
+                                    onClick={() => {console.log('클릭');navigate(`/board/${url}/create`);}}
                                 >
                                     <FlexDiv height="15px">
                                         <Div width="12px" height="12px" $margin="0 10px 0 0">

--- a/src/Components/Page/IBAS/Contest/Contest.tsx
+++ b/src/Components/Page/IBAS/Contest/Contest.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import useFetch from "../../../../Hooks/useFetch";
+
+import { Div, FlexDiv } from "../../../../styles/assets/Div";
+
+import ContestInfo from "../../../Component/Contest/ContestInfo";
+
+import { tokenAccess } from "../../../../Recoil/backState";
+import { useRecoilValue } from "recoil";
+import { useLocation } from "react-router-dom";
+
+const Contest = () => {
+    const [contestData, fetchContestData] = useFetch();
+    const accessToken = useRecoilValue(tokenAccess);
+    const [infos, setInfos] = useState([]);
+
+    const location = useLocation();
+    const url = location.pathname.split("/")[2];
+
+    useEffect(() => {
+        fetchContestData(`/contest/${url}?page=0&size=2&orderBy=DATE_CONTEST_END`, 'GET', 'token')
+    }, [accessToken])
+
+    useEffect(() => {
+        if (contestData) {
+            setInfos(contestData?.data)
+        }
+    }, [contestData])
+
+    return (
+        <>
+            <Div width="100%" height="600px" $border="2px solid" $borderColor="bk">
+                <FlexDiv width="100%" height="100%" $justifycontent="space-around">
+                    {infos?.map((data:any) => (
+                        <FlexDiv width="45%">
+                            <ContestInfo info={data} />
+                        </FlexDiv>
+                    ))}
+                </FlexDiv>
+            </Div>
+        </>
+    )
+}
+
+export default Contest;

--- a/src/Components/Page/IBAS/Contest/ContestCreate.tsx
+++ b/src/Components/Page/IBAS/Contest/ContestCreate.tsx
@@ -1,0 +1,435 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+
+import useFetch from "../../../../Hooks/useFetch";
+
+import { fileIdList } from "../../../../Recoil/backState";
+import { menuId, refetch, selectedFile } from "../../../../Recoil/frontState";
+
+import DragNDrop from "../../../Common/DragNDrop";
+import Loading from "../../../Common/Loading";
+import TextEditor from "../../../Common/TextEditor";
+
+import { theme } from "../../../../styles/theme";
+import Button from "../../../../styles/assets/Button";
+import { Container, Div, FlexDiv } from "../../../../styles/assets/Div";
+import Img from "../../../../styles/assets/Img";
+import { Date, TextInput, Radio, Label } from "../../../../styles/assets/Input";
+import P from "../../../../styles/assets/P";
+
+interface contestDetailInterface {
+    contestFieldId: number|null;
+    title: string;
+    topic: string;
+    association: string;
+    dateContestStart: string;
+    dateContestEnd: string;
+    content: string;
+    thumbnail: [        
+        {
+            id: string;
+            name: string;
+            url: string;
+            size: number;
+            type: string;
+        }
+    ];
+
+    id: number;
+    dday: number;
+    // D-day: number;
+}
+
+const ContestCreate = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const url = location.pathname.split("/")[2];
+    const paramID = useParams().id;
+
+    const inputRef = useRef<any[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [postData, postFetchData] = useFetch();
+    const [getData, getFetchData] = useFetch();
+    const [fileId, setFileList] = useRecoilState(fileIdList);
+    const [update, setUpdate] = useState("create");
+    const [detail, setDetail] = useState<contestDetailInterface | null>(null);
+    const setSelectedFile = useSetRecoilState(selectedFile);
+    const currentMenuId = useRecoilValue(menuId);
+    const setReload = useSetRecoilState(refetch);
+    const [contestType, setContestType] = useState<number|null>(null);
+
+    useEffect(() => {
+        if (paramID) {
+            setUpdate("update");
+        } else {
+            setIsLoading(false);
+        }
+    }, []);
+
+    let fetchUrl = "";
+    if (url === "contest") {
+        fetchUrl = "/contest/contest";
+    } else if (url === "activity") {
+        fetchUrl = "/contest/activity";
+    }
+
+    const sendInput = () => {
+        let check = true;
+
+        if (check && inputRef.current[0].value === "") {
+            alert("공모전 이름을 입력해주세요.");
+            check = false;
+        }
+        if (check && inputRef.current[1].value === "") {
+            alert("공모전 주제를 입력해주세요.");
+            check = false;
+        }
+        if (check && inputRef.current[2].value === "") {
+            alert("주최기관을 입력해주세요.");
+            check = false;
+        }
+        if (check && inputRef.current[3].value === "") {
+            alert("공모전 시작일을 입력해주세요.");
+            check = false;
+        }
+        if (check && inputRef.current[4].value === "") {
+            alert("공모전 마감일을 입력해주세요.");
+            check = false;
+        }
+
+        if (check && inputRef.current[5].value === "") {
+            alert("내용을 입력해주세요");
+            check = false;
+        }
+
+        if (check) {
+            setIsLoading(true); // 로딩 상태 설정
+            const inputData = {
+                contestFieldId: contestType === 1 ? '1' : contestType === 2 ? '2' : null,
+                title: inputRef.current[0].value,
+                topic: inputRef.current[1].value,
+                association: inputRef.current[2].value,
+                dateContestStart: inputRef.current[3].value + 'T00:00:00',
+                dateContestEnd: inputRef.current[4].value + 'T00:00:00',
+                content: inputRef.current[5].getInstance().getMarkdown(),
+                files: fileId,
+            };
+            console.log(inputData)
+            if (update === "create") {
+                postFetchData(`${fetchUrl}`, "POST", "token", inputData);
+            } else if (update === "update") {
+                postFetchData(`${fetchUrl}/${paramID}`, "POST", "token", inputData);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (postData) {
+            setIsLoading(false); // 로딩 상태 해제
+            alert("글이 정상적으로 등록되었습니다");
+            navigate(`/board/${url}`);
+        }
+    }, [postData]);
+
+    useEffect(() => {
+        console.log(update)
+        if (update == "update") {
+            getFetchData(`${fetchUrl}/${paramID}`, "GET", "token");
+        }
+    }, [update]);
+
+    useEffect(() => {
+        if (getData) {
+            setDetail(getData);
+            setContestType(getData.contestFieldId);
+            setIsLoading(false);
+            
+            // DragNDrop update 설정
+            const files = [
+                ...getData.images.map((item: contestDetailInterface|null) => item),
+                ...getData.otherFiles.map((item: contestDetailInterface|null) => item),
+            ];
+            setSelectedFile(files);
+            const fileIds = [
+                ...getData.images.map((item: contestDetailInterface|null) => item?.id),
+                ...getData.otherFiles.map((item: contestDetailInterface|null) => item?.id),
+            ];
+            setFileList(fileIds);
+            // DragNDrop reload true일 때만 불러온 파일들 렌더링 할 있음
+            setReload(true);
+        }
+        return () => {
+            setDetail(null);
+            // DragNDrop fileList 초기화
+            setFileList([]);
+        };
+    }, [getData]);
+    
+    return (
+        <FlexDiv width="100%">
+            {isLoading ? (
+                <Loading />
+            ) : (
+                <Container $alignitems="start">
+
+                    <Div width="100%" $margin="0 0 30px 0">
+                        <FlexDiv
+                            $padding="15px 20px"
+                            width="100%"
+                            $justifycontent="start"
+                            radius={5}
+                            $border="1px solid"
+                            $borderColor="bgColor"
+                        >
+                            <Div width="25px" height="25px" $margin="0 10px 0 0">
+                                <Img src="/images/triangle-warning_purple.svg"></Img>
+                            </Div>
+                            <Div>
+                                <P color="bgColor" fontSize="sm" fontWeight={700}>
+                                    웹사이트 운영 정책을 위반하는 게시글은 예고 없이 삭제 될 수 있습니다.
+                                </P>
+                            </Div>
+                        </FlexDiv>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 제목</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <TextInput
+                                        width="100%"
+                                        height="60px"
+                                        placeholder="공모전 이름을 입력하세요."
+                                        fontSize="xl"
+                                        $borderRadius={5}
+                                        ref={(el: never) => (inputRef.current[0] = el)}
+                                        defaultValue={detail?.title}
+                                    ></TextInput>
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 종류</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <FlexDiv width="90%" $justifycontent="flex-start" height="50px">
+                                        <FlexDiv>
+                                            <Radio
+                                                name="setHistoryType"
+                                                value={"빅데이터"}
+                                                ref={(el: never) => (inputRef.current[0] = el)}
+                                                onClick={() => {
+                                                    setContestType(1);
+                                                }}
+                                                defaultChecked={detail?.contestFieldId === 1}
+                                            />
+                                            <Label $margin="0 0 0 5px">빅데이터</Label>
+                                        </FlexDiv>
+                                        <FlexDiv $margin="0 90px">
+                                            <Radio
+                                                name="setHistoryType"
+                                                value={"IT"}
+                                                onClick={() => {
+                                                    setContestType(2);
+                                                }}
+                                                defaultChecked={detail?.contestFieldId === 2}
+                                            />
+                                            <Label $margin="0 0 0 5px">IT</Label>
+                                        </FlexDiv>
+                                        {/* null 해결 후 추가 */}
+
+                                        {/* <FlexDiv>
+                                            <Radio
+                                                name="setHistoryType"
+                                                value={"기타"}
+                                                onClick={() => {
+                                                    setContestType(null);
+                                                }}
+                                                defaultChecked={detail?.contestFieldId === null}
+                                            />
+                                            <Label $margin="0 0 0 5px">기타</Label>
+                                        </FlexDiv> */}
+                                    </FlexDiv>
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 주제</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <TextInput
+                                        width="100%"
+                                        height="60px"
+                                        placeholder="공모전 주제를 적어주세요."
+                                        fontSize="xl"
+                                        $borderRadius={5}
+                                        ref={(el: never) => (inputRef.current[1] = el)}
+                                        defaultValue={detail?.topic}
+                                    ></TextInput>
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 주최기관</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <TextInput
+                                        width="100%"
+                                        height="60px"
+                                        placeholder="주최기관을 입력하세요."
+                                        fontSize="xl"
+                                        $borderRadius={5}
+                                        ref={(el: never) => (inputRef.current[2] = el)}
+                                        defaultValue={detail?.association}
+                                    ></TextInput>
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 시작일</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <Date
+                                        width="100%"
+                                        height="60px"
+                                        fontSize="xl"
+                                        $borderRadius={5}
+                                        ref={(el: never) => (inputRef.current[3] = el)}
+                                        defaultValue={detail?.dateContestStart?.split('T')[0]}
+                                    />
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width=" 100%"
+                                $padding="20px"
+                                $justifycontent="space-between"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 마감일</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <Div width="100%">
+                                    <Date
+                                        width="100%"
+                                        height="60px"
+                                        fontSize="xl"
+                                        $borderRadius={5}
+                                        ref={(el: never) => (inputRef.current[4] = el)}
+                                        defaultValue={detail?.dateContestEnd?.split('T')[0]}
+                                    />
+                                </Div>
+                            </Div>
+                        </Div>
+
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width="100%"
+                                $padding="20px"
+                                $justifycontent="flex-start"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 포스터 및 첨부파일</P>
+                                </Div>
+                                <Div $margin="0 0 0 5px">
+                                    <P fontSize="xs" color="red" fontWeight={500}>※ 첨부파일에 사진 파일이 없을 시 정상적으로 게시글이 등록되지 않습니다.</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <DragNDrop fileFetch menuId={currentMenuId} />
+                            </Div>
+                        </Div>
+                        
+                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FlexDiv
+                                width="100%"
+                                $padding="20px"
+                                $justifycontent="flex-start"
+                                $borderB={`1px solid ${theme.color.border}`}
+                            >
+                                <Div>
+                                    <P fontWeight={600}>공모전 상세 설명</P>
+                                </Div>
+                            </FlexDiv>
+                            <Div width="100%" $padding="20px">
+                                <TextEditor
+                                    ref={(el: never) => (inputRef.current[5] = el)}
+                                    initialContent={detail?.content}
+                                />
+                            </Div>
+                        </Div>
+
+                        <FlexDiv width="100%" $margin="30px 0 0 0">
+                            <Button
+                                $backgroundColor="bgColor"
+                                $HBackgroundColor="bgColorHo"
+                                $borderRadius={2}
+                                $padding="15px 30px"
+                                width="400px"
+                                onClick={() => sendInput()}
+                            >
+                                {update === "create" ? <P color="wh">작성하기</P> : <P color="wh">수정하기</P>}
+                            </Button>
+                        </FlexDiv>
+                    </Div>
+                </Container>
+            )}
+        </FlexDiv>
+    );
+};
+
+export default ContestCreate;

--- a/src/Components/Page/IBAS/Contest/ContestDetail.tsx
+++ b/src/Components/Page/IBAS/Contest/ContestDetail.tsx
@@ -1,0 +1,196 @@
+import { Div, FlexDiv } from "../../../../styles/assets/Div";
+import P from "../../../../styles/assets/P";
+import Img from "../../../../styles/assets/Img";
+import { H2 } from "../../../../styles/assets/H";
+import Button from "../../../../styles/assets/Button";
+import A from "../../../../styles/assets/A";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import useFetch from "../../../../Hooks/useFetch";
+
+interface ContestDetailType {
+    id: number;
+    contestFieldId: number;
+    title: string;
+    content: string;
+    writerName: string;
+    association: string;
+    topic: string;
+    thumbnail: {
+        id: string;
+        name: string;
+        url: string;
+        size: number;
+        type: string;
+    };
+    images: {
+        id: string;
+        name: string;
+        url: string;
+        size: number;
+        type: string;
+    }[];
+    otherFiles: any[]; // 이 부분은 다른 파일의 구조를 알 수 없으므로 any로 지정했습니다.
+    dateContestStart: string;
+    dateContestEnd: string;
+    dateCreated: string;
+    dateUpdated: string;
+}
+
+
+
+const ContestDetail = () => {
+
+// curl -X 'GET' \'https://dev.inhabas.com/api/contest/CONTEST/181'
+
+//     {
+//   "id": 181,
+//   "contestFieldId": 2,
+//   "title": "빅데이터",
+//   "content": "stringABC",
+//   "writerName": "김지성",
+//   "association": "string",
+//   "topic": "string",
+//   "thumbnail": {
+//     "id": "b98bd7bf-1e58-42da-b840-8a807d399310",
+//     "name": "KakaoTalk_20240330_204240989 (1).jpg",
+//     "url": "https://inhabas-bucket.s3.ap-northeast-2.amazonaws.com/CONTEST/b98bd7bf-1e58-42da-b840-8a807d399310_KakaoTalk_20240330_204240989%20%281%29.jpg",
+//     "size": 61640,
+//     "type": "image/jpeg"
+//   },
+//   "images": [
+//     {
+//       "id": "b98bd7bf-1e58-42da-b840-8a807d399310",
+//       "name": "KakaoTalk_20240330_204240989 (1).jpg",
+//       "url": "https://inhabas-bucket.s3.ap-northeast-2.amazonaws.com/CONTEST/b98bd7bf-1e58-42da-b840-8a807d399310_KakaoTalk_20240330_204240989%20%281%29.jpg",
+//       "size": 61640,
+//       "type": "image/jpeg"
+//     }
+//   ],
+//   "otherFiles": [],
+//   "dateContestStart": "2024-05-01T00:00:00",
+//   "dateContestEnd": "2024-11-01T00:00:00",
+//   "dateCreated": "2024-04-09T10:45:23",
+//   "dateUpdated": "2024-04-20T01:26:55"
+// }
+
+    const location = useLocation();
+    const contentId = location.pathname.split("/")[4];
+    const [detailData, detailDataFetch] = useFetch();
+    const [detail, setDetail] = useState<ContestDetailType|null>(null);
+
+    useEffect(() => {
+        detailDataFetch(`contest/contest/${contentId}`, 'GET', 'token')
+    }, [])
+
+    useEffect(() => {
+        setDetail(detailData);
+        console.log(detailData)
+    }, [detailData])
+
+    return (
+        <>
+            {/* 컨테이너 */}
+            <Div width="73%" $margin="50px 0 100px 0" direction="column">
+                {/* 작성 info */}
+                <FlexDiv $margin="50px 0 30px 0">
+                    <FlexDiv width="12px" $margin="0 5px 0 0">
+                        <Img src="/images/user_grey.svg" />
+                    </FlexDiv>
+                    <Div>
+                        <P color="grey4" fontSize="sm">
+                            By {detail?.writerName} |
+                        </P>
+                    </Div>
+                    <FlexDiv width="12px" $margin="0 5px ">
+                        <Img src="/images/clock_grey.svg" />
+                    </FlexDiv>
+                    <Div>
+                        <P color="grey4" fontSize="sm">
+                            작성일시
+                            {/* {formatDateMinute({ date: detail?.dateCreated || "" })} */}
+                        </P>
+                    </Div>
+                </FlexDiv>
+
+                {/* 게시글 title */}
+                <Div>
+                    <H2 fontSize="xxl" fontWeight={800}>
+                        게시글 title
+                    </H2>
+                </Div>
+
+                {/* 주최기관, 개최기간 */}
+                <FlexDiv $padding="30px 0" width="100%" $justifycontent="flex-start">
+                {/* <FlexDiv $padding="30px 0" width="100%" $borderB="2px solid" $borderColor="border" $justifycontent="flex-start"> */}
+                    <Div>
+                        <P color="grey4" fontSize="sm">주최기관 |</P>
+                    </Div>
+                    <Div $margin="0 5px">
+                        <P color="grey4" fontSize="sm">시작 ~ 끝</P>
+                    </Div>
+                </FlexDiv>
+                
+                {/* 공모전 주제 */}
+                <FlexDiv width="100%" $border="2px solid" $borderColor="border" $padding="20px">
+                    <Div>
+                        <P fontSize="lg" fontWeight={800}>공모전 주제</P>
+                    </Div>
+                </FlexDiv>
+                <FlexDiv width="100%" $border="2px solid" $borderColor="border" $padding="50px">
+                    <Div>
+                        <P fontSize="md">상세 주제</P>
+                    </Div>
+                </FlexDiv>
+
+                {/* 사진들 */}
+
+                <Div width="100%" $border="2px solid blue" $borderColor="blue" $margin="50px 0">
+                    <Img src="/images/sponsor.png" />
+                    <P>사진 꽉 채우기</P>
+                </Div>
+                <Div width="100%" height="200px" $border="2px solid blue" $borderColor="blue" $margin="50px 0">
+                    <P>사진 꽉 채우기</P>
+                </Div>
+                <Div width="100%" height="200px" $border="2px solid blue" $borderColor="blue" $margin="50px 0">
+                    <P>사진 꽉 채우기</P>
+                </Div>
+
+                <Div>
+                    <P>상세설명 쭉 나열</P>
+                </Div>
+
+                <div>hi</div>
+                <div>hi</div>
+                <div>hi</div>
+                <div>hi</div>
+
+                <FlexDiv width="100%" $justifycontent="end" $margin="20px 0 0 0">
+                    <Button
+                        display="flex"
+                        $backgroundColor="bgColor"
+                        $margin="0 10px 0 0"
+                        $padding="12px 15px"
+                        $borderRadius={30}
+                        $HBackgroundColor="bgColorHo"
+                        // onClick={() => navigate(`/board/${url}/create`)}
+                    >
+                        <FlexDiv height="15px">
+                            <Div width="12px" height="12px" $margin="0 10px 0 0">
+                                <Img src="/images/plus_white.svg" />
+                            </Div>
+                        </FlexDiv>
+                        <Div $pointer height="15px">
+                            <A color="wh" fontSize="sm" $hoverColor="wh">
+                                게시글 작성
+                            </A>
+                        </Div>
+                    </Button>
+                </FlexDiv>
+            </Div>
+        </>
+    )
+
+}
+
+export default ContestDetail;

--- a/src/Recoil/backState.tsx
+++ b/src/Recoil/backState.tsx
@@ -53,8 +53,7 @@ export const __totalPageInfo = atom({
 
 export const tokenAccess = atom({
     key: "tokenAccess",
-    default: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMTA5MTMyNjAyMjgyMTE4MzU0OTIiLCJtZW1iZXJJZCI6NjIsInByb3ZpZGVyIjoiR09PR0xFIiwiZW1haWwiOiIxMjE4MDU0M0BpbmhhLmVkdSIsImF1dGhvcml0aWVzIjpbIlJPTEVfRVhFQ1VUSVZFUyJdLCJpYXQiOjE3MTM4MzE2NTcsImV4cCI6MTcxMzgzMzQ1N30.1dIunl2jSPCPgtwGpOzDVBP_h8rt7B-02d3gFtON73Tg5_wNCRbFXWunb_XNA4SNH35YVfzMIJBHSkW0J-ekTQ",
-    // default: "default",
+    default: "default",
 });
 
 export const userEmail = atom({

--- a/src/Recoil/backState.tsx
+++ b/src/Recoil/backState.tsx
@@ -53,7 +53,8 @@ export const __totalPageInfo = atom({
 
 export const tokenAccess = atom({
     key: "tokenAccess",
-    default: "default",
+    default: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMTA5MTMyNjAyMjgyMTE4MzU0OTIiLCJtZW1iZXJJZCI6NjIsInByb3ZpZGVyIjoiR09PR0xFIiwiZW1haWwiOiIxMjE4MDU0M0BpbmhhLmVkdSIsImF1dGhvcml0aWVzIjpbIlJPTEVfRVhFQ1VUSVZFUyJdLCJpYXQiOjE3MTM4MzE2NTcsImV4cCI6MTcxMzgzMzQ1N30.1dIunl2jSPCPgtwGpOzDVBP_h8rt7B-02d3gFtON73Tg5_wNCRbFXWunb_XNA4SNH35YVfzMIJBHSkW0J-ekTQ",
+    // default: "default",
 });
 
 export const userEmail = atom({
@@ -210,6 +211,11 @@ export const boardListPinnedDataInfo = atom({
 
 export const boardDetailData = atom<boardDetailInterface | null>({
     key: "boardDetailData",
+    default: null,
+});
+
+export const contestListDataInfo = atom({
+    key: "contestListDataInfo",
     default: null,
 });
 

--- a/src/Routes/BoardRoute.tsx
+++ b/src/Routes/BoardRoute.tsx
@@ -7,6 +7,8 @@ import BoardList from "../Components/Page/Board/BoardList";
 import { GetRoleAuthorization } from "../Functions/authFunctions";
 import { userRole } from "../Recoil/backState";
 import { failRefreshing } from "../Recoil/frontState";
+import ContestDetail from "../Components/Page/IBAS/Contest/ContestDetail";
+import ContestCreate from "../Components/Page/IBAS/Contest/ContestCreate";
 
 const BoardRoute = () => {
     const navigate = useNavigate();
@@ -90,6 +92,16 @@ const BoardRoute = () => {
             <Route path="usage" element={<BoardList />} />
             <Route path="usage/detail/:id" element={<BoardDetail />} />
             <Route path="usage/create" element={<BoardCreate />} />
+            
+            <Route path="contest" element={<BoardList />} />
+            <Route path="contest/detail/:id" element={<ContestDetail />} />
+            <Route path="contest/create" element={<ContestCreate />} />
+            <Route path="contest/update/:id" element={<ContestCreate />} />
+            
+            <Route path="activity" element={<BoardList />} />
+            <Route path="activity/detail/:id" element={<ContestDetail />} />
+            <Route path="activity/create" element={<ContestCreate />} />
+            <Route path="activity/update/:id" element={<ContestCreate />} />
         </Routes>
     );
 };


### PR DESCRIPTION

1. [feat/#383] fix: backState 토큰 값 제거

2. [feat/#383] feat: ContestInfo 컴포넌트 추가

3. [feat/#383] feat: Contest Page 추가
    Contest: 공모전 페이지
    ContestCreate: 공모전 게시글 추가 페이지
    ContestDetail: 공모전 상세 페이지

4. [feat/#383] feat: BoardSearch와 BaordList에 공모전 요소 추가
    BoardSearch: 공모전 패치 코드 추가
    BoardList: url이 contest 관련일 경우 Contest 컴포넌트 렌더링

5. [feat/#383] feat: backState에 contestListDataInfo 추가

6. [feat/#383] feat: contest, activity 경로 추가

    dragNDrop : url 변경으로 board 안에 contest, activity 추가
    HeaderNav : url 변경으로 board 안에 contest, activity 추가, 공모전 메뉴 접근 불가 해제
    HeaderTitle : url 변경으로 board 안에 contest, activity 추가, 로그인 하지 않아도 공모전 메뉴 조회 가능
    BoardNavigate : 메뉴 패치 url에 공모전 추가
    BoardRoute : contest와 activity 라우팅 처리