### PR TITLE
[feat/#383] feat: Contest 게시판 대외활동 추가

### DIFF
--- a/src/Components/Component/Board/BoardSearch.tsx
+++ b/src/Components/Component/Board/BoardSearch.tsx
@@ -54,7 +54,7 @@ const BoardSearch = () => {
             if (['usage', 'sponsor'].includes(url)) {
                 fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=15`, "GET");
             } else if (['contest', 'activity'].includes(url)) {
-                fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=2&orderBy=DATE_CONTEST_END`, "GET");
+                fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=4&orderBy=DATE_CONTEST_END`, "GET");
             }
             else {
                 fetchBoardListData(`${fetchUrl}?search=${inputRef.current.value}&page=0&size=15`, "GET", "token");

--- a/src/Components/Component/Contest/ContestInfo.tsx
+++ b/src/Components/Component/Contest/ContestInfo.tsx
@@ -2,11 +2,13 @@ import { Div, FlexDiv } from "../../../styles/assets/Div";
 import P from "../../../styles/assets/P";
 import Img from "../../../styles/assets/Img";
 import Button from "../../../styles/assets/Button";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const ContestInfo = ({ info }: {info: any}) => {
 
     const navigate = useNavigate();
+    const location = useLocation();
+    const url = location.pathname.split("/")[2];
 
     const data = {
         thumbnailUrl: info?.thumbnail?.url,
@@ -18,26 +20,23 @@ const ContestInfo = ({ info }: {info: any}) => {
         topic: info?.topic,
         id: info?.id,
     }
+
     return (
         <>
             {/* 추후에 width 변경 */}
             <Div width="360px" height="600px" $border="1px solid" $borderColor="border">
-            {/* <Div $minWidth="370px" width="100%" height="600px" $border="1px solid" $borderColor="border"> */}
                     {/* 사진 영역 */}
                     <Div $minWidth="100%" width="100%" height="70%" $border="1px solid" $borderColor="border">
-                        <Button width="100%" height="100%" onClick={() => navigate(`/board/contest/detail/${data?.id}`)}>
+                        <Button width="100%" height="100%" onClick={() => navigate(`/board/${url}/detail/${data?.id}`)}>
                             <Img src={data?.thumbnailUrl} width='100%' />
-                            {/* <Img src={data?.thumbnailUrl} width='100%' /> */}
                         </Button>
                     </Div>
                     {/* 내용 영역 */}
                     <Div height="30%"width="100%">
                         {/* 윗 내용 */}
                         <FlexDiv height="70%" width="100%" $padding="20px 0">
-                        {/* <FlexDiv height="70%" width="100%" $padding="20px" $border="1px solid" $borderColor="border"> */}
                             {/* 마감 날짜 */}
                             <Div width="20%" height="100%" $margin="0 10px">
-                            {/* <Div width="30%" height="100%" $border="1px solid" $borderColor="border"> */}
                                 <FlexDiv width="100%">
                                     <Div>
                                         <P color="blue" fontSize="sm" fontWeight={600}>{data?.endMonth}월</P>
@@ -56,7 +55,6 @@ const ContestInfo = ({ info }: {info: any}) => {
                             </Div>
                             {/* 공모전 정보 */}
                             <Div width="70%" height="100%">
-                            {/* <Div width="70%" height="100%" $border="1px solid" $borderColor="border"> */}
                                 <Div width="100%">
                                     <P fontSize="lg" fontWeight={700}>{data?.title}</P>
                                 </Div>

--- a/src/Components/Page/Board/BoardList.tsx
+++ b/src/Components/Page/Board/BoardList.tsx
@@ -60,9 +60,9 @@ const BoardList = () => {
     } else if (url === "opensource") {
         fetchUrl = "/board/storage";
     } else if (url === "contest") {
-        fetchUrl = "/contest/contest?size=2&orderBy=DATE_CONTEST_END";
+        fetchUrl = "/contest/contest?size=4&orderBy=DATE_CONTEST_END";
     } else if (url === "activity") {
-        fetchUrl = "/contest/activity?size=2&orderBy=DATE_CONTEST_END";
+        fetchUrl = "/contest/activity?size=4&orderBy=DATE_CONTEST_END";
     } else {
         fetchUrl = `/board/${url}`;
     }

--- a/src/Components/Page/IBAS/Contest/Contest.tsx
+++ b/src/Components/Page/IBAS/Contest/Contest.tsx
@@ -1,33 +1,72 @@
-import { useEffect, useState } from "react";
-import useFetch from "../../../../Hooks/useFetch";
-
 import { Div, FlexDiv } from "../../../../styles/assets/Div";
 
 import ContestInfo from "../../../Component/Contest/ContestInfo";
 
 import { useRecoilValue } from "recoil";
-
 import { contestListDataInfo } from "../../../../Recoil/backState";
 
 const Contest = () => {
     const infos = useRecoilValue(contestListDataInfo)
-    
+
     return (
         <>
-            <Div width="100%" height="600px">
-                <FlexDiv width="100%" height="100%" $justifycontent="space-around">
-                    {infos && infos?.length === 2 && infos?.map((data:any) => (
-                        <FlexDiv width="45%">
-                            <ContestInfo info={data} />
+            <Div width="100%">
+                <Div width="100%" height="100%">
+                    {infos && infos?.length === 4 && (
+                        <>
+                            <FlexDiv width="100%" $justifycontent="space-between">
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[0]} />
+                                </FlexDiv>
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[1]} />
+                                </FlexDiv>
+                            </FlexDiv>
+                            <FlexDiv width="100%" $justifycontent="space-between" $margin="50px 0 0 0">
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[2]} />
+                                </FlexDiv>
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[3]} />
+                                </FlexDiv>
+                            </FlexDiv>
+                        </>
+                    )}
+                    {infos && infos?.length === 3 && (
+                        <>
+                            <FlexDiv width="100%" $justifycontent="space-between">
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[0]} />
+                                </FlexDiv>
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[1]} />
+                                </FlexDiv>
+                            </FlexDiv>
+                            <Div width="100%" $margin="50px 0 0 0">
+                                <FlexDiv width="45%">
+                                    <ContestInfo info={infos[2]} />
+                                </FlexDiv>
+                            </Div>
+                        </>
+                    )}
+                    {infos && infos?.length === 2 && (
+                        <FlexDiv width="100%" $justifycontent="space-between">
+                            <FlexDiv width="45%">
+                                <ContestInfo info={infos[0]} />
+                            </FlexDiv>
+                            <FlexDiv width="45%">
+                                <ContestInfo info={infos[1]} />
+                            </FlexDiv>
                         </FlexDiv>
-                    ))}
-                    {infos && infos?.length === 1 && infos?.map((data:any) => (
-                        <FlexDiv width="90%">
-                            <ContestInfo info={data} />
-                            <Div width="360px" />
-                        </FlexDiv>
-                    ))}
-                </FlexDiv>
+                    )}
+                    {infos && infos?.length === 1 && (
+                        <Div width="720px">
+                            <FlexDiv width="45%">
+                                <ContestInfo info={infos[0]} />
+                            </FlexDiv>
+                        </Div>
+                    )}
+                </Div>
             </Div>
         </>
     )

--- a/src/Components/Page/IBAS/Contest/ContestCreate.tsx
+++ b/src/Components/Page/IBAS/Contest/ContestCreate.tsx
@@ -236,7 +236,6 @@ const ContestCreate = () => {
                                             <Radio
                                                 name="setHistoryType"
                                                 value={"빅데이터"}
-                                                ref={(el: never) => (inputRef.current[0] = el)}
                                                 onClick={() => {
                                                     setContestType(1);
                                                 }}


### PR DESCRIPTION
- BoardSearch : 공모전 게시판 fetch size 2에서 4로 변경
- ContestInfo : url 변수를 이용하여 대외활동 fetch 적용
- BoardList : 공모전 게시판 fetch size 2에서 4로 변경
- Contest : 게시글 개수별 ui css 적용
- ContestCreate : 사용하지 않는 요소인 radio박스의 ref 제거
- ContestDetail : fetch와 요소들에 대외활동 적용 후 게시글 수정, 삭제 추가