### PR TITLE
Fix/#428 공모전 게시판 버그 수정

### DIFF
--- a/src/Components/Component/Contest/ContestInfo.tsx
+++ b/src/Components/Component/Contest/ContestInfo.tsx
@@ -59,10 +59,6 @@ const ContestInfo = ({ info }: {info: any}) => {
                     {/* 진행 상태 */}
                     <Div width="100%" $margin="0 0 20px 0" $padding="5px 0">
                         <FlexDiv width="39%">
-                            {/* dday null 해결 후 삭제 */}
-                            <Div $border="2px solid" $borderColor="red" $padding="3px" radius={5}>
-                                <P color="red" fontWeight={700}>마감</P>
-                            </Div>
                             {(data?.dday < 0) &&
                                 (
                                     <Div $border="2px solid" $borderColor="red" $padding="3px" radius={5}>

--- a/src/Components/Page/Board/BoardList.tsx
+++ b/src/Components/Page/Board/BoardList.tsx
@@ -215,8 +215,9 @@ const BoardList = () => {
                         {contestListData && contestListData.length !== 0 && (
                             <Pagination
                                 totalPage={totalPage}
-                                fetchUrl={`${fetchUrl}`}
+                                fetchUrl={`/contest/${url}?${contestOrderBy}`}
                                 paginationFetch={fetchBoardListData}
+                                size={4}
                             />
                         )}
                     </Div>

--- a/src/Components/Page/IBAS/Contest/Contest.tsx
+++ b/src/Components/Page/IBAS/Contest/Contest.tsx
@@ -14,7 +14,7 @@ const Contest = () => {
     return (
         <>
             <Div width="100%" $position="relative">
-                <Div $position="absolute" $top="-50px" $right="0px" width="100px">
+                <Div $position="absolute" $top="-50px" $right="10px" width="100px">
                     <Dropdown
                         label={order === '&orderBy=ALL' ? '전체보기' : '진행중'}
                         options={["전체보기", "진행중"]}
@@ -77,6 +77,11 @@ const Contest = () => {
                                 <ContestInfo info={infos[0]} />
                             </FlexDiv>
                         </Div>
+                    )}
+                    {infos && infos?.length === 0 && (
+                        <FlexDiv width="720px">
+                            게시글이 존재하지 않습니다
+                        </FlexDiv>
                     )}
                 </Div>
             </Div>

--- a/src/Components/Page/IBAS/Contest/ContestDetail.tsx
+++ b/src/Components/Page/IBAS/Contest/ContestDetail.tsx
@@ -177,7 +177,6 @@ const ContestDetail = () => {
                     
                     {/* 주제 */}
                     <FlexDiv width="100%" $borderT={`2px solid ${theme.color.border}`} $padding="20px">
-                    {/* <FlexDiv width="100%" $border="2px solid" $borderColor="border" $padding="20px"> */}
                         <Div>
                             {url === 'contest' && (<P fontSize="xl" fontWeight={800}>공모전 주제</P>)}
                             {url === 'activity' && (<P fontSize="xl" fontWeight={800}>대외활동 주제</P>)}


### PR DESCRIPTION
1. fix: api의 dday 완성 후 공모전 게시판 게시글 상태 정상적으로 수정
2. fix: 공모전 게시판에서 진행중 상태 선택 후 페이지 변경 시 오류 수정
- pagination의 fetchUrl을 수정하여 상태 선택 후 페이지 변경 시에도 올바르게 게시물 표시하도록 수정
3. feat: 공모전 게시판에 게시글이 존재하지 않았을 때 안내 문구 추가
- 해당 조건에 대한 게시글이 존재하지 않을 때 '게시글이 존재하지 않습니다'라는 문구 출력
- 진행중인 공모전, 대외활동이 없을 때 필요