### PR TITLE
[design/#429] fix: filter 함수를 통해 모임 탭 제거

### DIFF
--- a/src/Components/Common/HeaderNav.tsx
+++ b/src/Components/Common/HeaderNav.tsx
@@ -276,7 +276,9 @@ const HeaderNav = () => {
                         <FlexDiv>
                             <FlexDiv>
                                 {nav &&
-                                    Object.values(nav).map((item: any, idx: number) => {
+                                    // 아래는 모임 탭 제거 전 코드
+                                    // Object.values(nav).map((item: any, idx: number) => {
+                                    Object.values(nav).filter((item: any) => {return item.groupName !== '모임'}).map((item: any, idx: number) => {
                                         return (
                                             <Div $position="relative" key={idx}>
                                                 <FlexDiv


### PR DESCRIPTION
- filter를 통해 item.groupName이 모임인 경우를 제거하여 모임이라는 탭을 보이지 않게 함