### PR TITLE
[fix/#492] 비회원 권한에 따른 댓글 관련 코드 수정

### DIFF
--- a/src/Components/Common/CommentList.tsx
+++ b/src/Components/Common/CommentList.tsx
@@ -122,6 +122,9 @@ const CommentList = (props: commentPropsInterface) => {
         }
         setUpdating("nothing");
         setEditingCommentId(-1);
+        return (
+            setComment([])
+        )
     }, [commentDeleteData, putComment]);
 
     useEffect(() => {

--- a/src/Components/Page/Board/BoardDetail.tsx
+++ b/src/Components/Page/Board/BoardDetail.tsx
@@ -56,7 +56,7 @@ const BoardDetail = () => {
     const navigate = useNavigate();
     const url = location.pathname.split("/")[2];
     const boardId = location.pathname.split("/")[4];
-    const { isAuthorizedOverVice } = GetRoleAuthorization();
+    const { isAuthorizedOverVice, isAuthorizedOverDeactivate } = GetRoleAuthorization();
 
     const { formatDateMinute } = DateFunction();
 
@@ -381,8 +381,16 @@ const BoardDetail = () => {
                                 )}
                             </FlexDiv>
                         </Div>
-                        <CommentList boardId={boardId} menuId={titleInfo(pathNameInfo[0], pathNameInfo[1])} />
-                        <CommentInput boardId={boardId} menuId={titleInfo(pathNameInfo[0], pathNameInfo[1])} />
+                        {/* 공개자료실일 경우에 토큰 없이 댓글 패치 */}
+                        {pathNameInfo[1] === 'opensource' ? (
+                            <CommentList boardId={boardId} menuId={titleInfo(pathNameInfo[0], pathNameInfo[1])} token={false} />
+                        )
+                        : (
+                            <CommentList boardId={boardId} menuId={titleInfo(pathNameInfo[0], pathNameInfo[1])} />
+                        )}
+                        {isAuthorizedOverDeactivate && (
+                            <CommentInput boardId={boardId} menuId={titleInfo(pathNameInfo[0], pathNameInfo[1])} />
+                        )}
                     </DetailContainer>
                 </FlexDiv>
             )}

--- a/src/Components/Page/IBAS/Contest/ContestDetail.tsx
+++ b/src/Components/Page/IBAS/Contest/ContestDetail.tsx
@@ -353,7 +353,7 @@ const ContestDetail = () => {
                             </Button>
                         )}
                     </FlexDiv>
-                    <CommentList boardId={boardId} menuId={menuId} />
+                    <CommentList boardId={boardId} menuId={menuId} token={false} />
                     {isAuthorizedOverDeactivate && (
                         <>
                             <CommentInput boardId={boardId} menuId={menuId} />


### PR DESCRIPTION
- CommentList: 댓글 패치 useEffect의 return에 댓글을 초기화하는 코드를 추가
- BoardDetail: 공개 자료실 댓글 토큰 없이 패치
- ContestDetail: 공모전 게시판 댓글 토큰 없이 패치