### PR TITLE
[fix/#517] 회계내역 memberId 요소 추가

### DIFF
--- a/src/Components/Common/Modal/ModalPostBankHistory.tsx
+++ b/src/Components/Common/Modal/ModalPostBankHistory.tsx
@@ -37,6 +37,7 @@ const ModalPostBankHistory = () => {
         "dateUsed": "",
         "title": "",
         "details": "",
+        "memberIdReceived": "",
         "memberStudentIdReceived": "",
         "memberNameReceived": "",
         "income": '0',
@@ -50,6 +51,7 @@ const ModalPostBankHistory = () => {
         "dateUsed": "",
         "title": "",
         "details": "",
+        "memberIdReceived": "",
         "memberStudentIdReceived": "",
         "memberNameReceived": "",
         "income": '',
@@ -86,6 +88,7 @@ const ModalPostBankHistory = () => {
         if (infos.details.length === 0) {
             infos.details = infos.title
         } 
+        infos.memberIdReceived = selectedInfos.memberId;
         infos.memberStudentIdReceived = selectedInfos.studentId;
         infos.memberNameReceived = selectedInfos.name;
 
@@ -94,6 +97,7 @@ const ModalPostBankHistory = () => {
             dateUsed: infos.dateUsed.includes('T') ? infos.dateUsed : infos.dateUsed += 'T00:00:00',
             title: infos.title,
             details: infos.details,
+            memberIdReceived: infos.memberIdReceived === "" ? null : infos.memberIdReceived,
             memberStudentIdReceived: infos.memberStudentIdReceived === "" ? null : infos.memberStudentIdReceived,
             memberNameReceived: infos.memberNameReceived === "" ? null : infos.memberNameReceived,
             income: Number(infos.income),
@@ -110,7 +114,7 @@ const ModalPostBankHistory = () => {
             setReload(true);
             resetInfos();
             // 선택 학생 초기화
-            setSelectedInfos({ name: "", major: '', studentId: '' })
+            setSelectedInfos({ name: "", major: '', studentId: '', memberId: '' })
             // 파일 리스트 초기화
             setFiles([])
         }

--- a/src/Components/Common/Modal/ModalUpdateBankHistory.tsx
+++ b/src/Components/Common/Modal/ModalUpdateBankHistory.tsx
@@ -40,6 +40,7 @@ const ModalUpdateBankHistory = () => {
         "dateUsed": "",
         "title": "",
         "details": "",
+        "memberIdReceived": "",
         "memberStudentIdReceived": "",
         "memberNameReceived": "",
         "income": '0',
@@ -55,6 +56,7 @@ const ModalUpdateBankHistory = () => {
         if (historyInfo) {
             setSelectedInfos(prev => ({
                 ...prev,
+                memberId: historyInfo?.memberIdReceived,
                 name: historyInfo?.memberNameReceived,
                 studentId: historyInfo?.memberStudentIdReceived
             }));
@@ -90,6 +92,7 @@ const ModalUpdateBankHistory = () => {
         "dateUsed": "",
         "title": "",
         "details": "",
+        "memberIdReceived": "",
         "memberStudentIdReceived": "",
         "memberNameReceived": "",
         "income": '',
@@ -126,6 +129,7 @@ const ModalUpdateBankHistory = () => {
         if (infos.details.length === 0) {
             infos.details = infos.title
         } 
+        infos.memberIdReceived = selectedInfos.memberId;
         infos.memberStudentIdReceived = selectedInfos.studentId;
         infos.memberNameReceived = selectedInfos.name;
 
@@ -149,7 +153,7 @@ const ModalUpdateBankHistory = () => {
             closeModal();
             setReload(true);
             resetInfos();
-            setSelectedInfos({ name: "", major: '', studentId: '' })
+            setSelectedInfos({ name: "", major: '', studentId: '', memberId: '' })
             // 파일 리스트 초기화
             setFileIdList([])
         }

--- a/src/Recoil/frontState.tsx
+++ b/src/Recoil/frontState.tsx
@@ -72,7 +72,7 @@ export const selectedFile = atom<any[]>({
 // bank
 export const selectedStudentInfos = atom({
     key: "selectedStudentInfos",
-    default: { name: "", major: "", studentId: "" },
+    default: { name: "", major: "", studentId: "", memberId: "" },
 });
 
 export const bankSupportRejectReasonInfo = atom({


### PR DESCRIPTION
- frontState: selectedStudentInfos에 memberId 추가
- ModalPostBankHistory: memberIdReceived 추가
- ModalUpdateBankHistory: memberIdReceived 추가