### PR TITLE
workflow get github actions ip 방식 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get GitHub Actions IP
         id: ip
         if: always()
-        uses: haythem/public-ip@v1.3
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials
         if: always()


### PR DESCRIPTION
`haythem/public-ip` 액션이 종종 실패하는 문제로 인해 더 안정적인 방식으로 변경