### PR TITLE
[feat/#617] 반응형 공통 레이아웃 및 내비게이션 구현

### DIFF
--- a/src/components/common/Bottom.tsx
+++ b/src/components/common/Bottom.tsx
@@ -9,6 +9,7 @@ import A from "../../styles/assets/A";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const BottomDiv = styled(FlexDiv)`
     background-image: url("/images/bottom.jpg");
@@ -16,6 +17,117 @@ const BottomDiv = styled(FlexDiv)`
     background-position: center center;
     background-size: cover;
     position: relative;
+
+    ${media.tablet} {
+        height: auto;
+    }
+`;
+
+const BottomContent = styled(FlexDiv)`
+    width: 100%;
+    justify-content: space-around;
+    padding: 20px 0;
+
+    ${media.tablet} {
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 32px 24px;
+    }
+
+    ${media.mobile} {
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        padding: 40px 16px 32px;
+    }
+`;
+
+const FooterLogo = styled(Div)`
+    width: 350px;
+
+    ${media.desktop} {
+        width: 28%;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 240px;
+    }
+`;
+
+const ContactColumn = styled(FlexDiv)`
+    width: 350px;
+    height: 180px;
+
+    ${media.desktop} {
+        width: 38%;
+    }
+
+    ${media.tablet} {
+        height: auto;
+        gap: 14px;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 360px;
+        align-items: flex-start;
+    }
+`;
+
+const ContactRow = styled(FlexDiv)`
+    width: 100%;
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+
+    & > div:last-child {
+        min-width: 0;
+        white-space: normal;
+    }
+`;
+
+const ContactText = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.5;
+`;
+
+const Terms = styled(FlexDiv)`
+    width: 100%;
+    padding: 20px;
+    border: 1px solid ${props => props.theme.color.bk};
+
+    ${media.mobile} {
+        gap: 8px 0;
+        padding: 18px 16px;
+    }
+`;
+
+const Term = styled(FlexDiv)`
+    white-space: normal;
+
+    ${media.mobile} {
+        justify-content: center;
+    }
+`;
+
+const Credits = styled(FlexDiv)`
+    height: 70px;
+
+    p {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        text-align: center;
+    }
+
+    ${media.mobile} {
+        height: auto;
+        gap: 8px;
+        padding: 20px 16px 28px;
+    }
 `;
 
 const Bottom = () => {
@@ -42,69 +154,67 @@ const Bottom = () => {
     return (
         <>
             <BottomDiv width="100%" height="350px">
-                <FlexDiv width="100%" $justifycontent="space-around" $padding="20px 0">
-                    <Div width="350px">
+                <BottomContent>
+                    <FooterLogo>
                         <Img src="/images/logo_white.png" />
-                    </Div>
-                    <FlexDiv
+                    </FooterLogo>
+                    <ContactColumn
                         direction="column"
                         $justifycontent="space-around"
                         $alignitems="start"
-                        width="350px"
-                        height="180px"
                     >
                         <Div>
                             <P color="wh" fontWeight={800} fontSize="lg">
                                 Contact Us
                             </P>
                         </Div>
-                        <FlexDiv>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/user_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.name}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/location_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     인하대학교 22212 인천광역시 미추홀구 인하로 100
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/phone_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.phoneNumber}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/envelope_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.email}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                    </FlexDiv>
-                    <Div width="350px">
+                        </ContactRow>
+                    </ContactColumn>
+                    <FooterLogo>
                         <Img src="/images/inha-en-logo_white.png" />
-                    </Div>
-                </FlexDiv>
-                <FlexDiv width="100%" $padding="20px" $border="1px solid" $borderColor="bk">
-                    <FlexDiv $pointer>
+                    </FooterLogo>
+                </BottomContent>
+                <Terms>
+                    <Term $pointer>
                         <Div>
                             <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(1)}>
                                 제3자에 관한 개인정보 이용제공 동의 약관
@@ -113,8 +223,8 @@ const Bottom = () => {
                         <Div $margin="0 5px">
                             <P color="wh">·</P>
                         </Div>
-                    </FlexDiv>
-                    <FlexDiv $pointer>
+                    </Term>
+                    <Term $pointer>
                         <Div>
                             <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(2)}>
                                 동아리 회칙
@@ -123,14 +233,14 @@ const Bottom = () => {
                         <Div $margin="0 5px">
                             <P color="wh">·</P>
                         </Div>
-                    </FlexDiv>
-                    <FlexDiv $pointer>
+                    </Term>
+                    <Term $pointer>
                         <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(3)}>
                             홈페이지 이용약관
                         </A>
-                    </FlexDiv>
-                </FlexDiv>
-                <FlexDiv direction="column" $justifycontent="space-around" $padding="20px 0 " height="70px">
+                    </Term>
+                </Terms>
+                <Credits direction="column" $justifycontent="space-around" $padding="20px 0 ">
                     <Div>
                         <P color="wh" fontSize="xs">
                             2021 Developed By 양태영, 신승연, 김채림, 윤예진, 유동현
@@ -141,7 +251,7 @@ const Bottom = () => {
                             2024 Developed By 조승현, 윤예진, 송민석
                         </P>
                     </Div>
-                </FlexDiv>
+                </Credits>
             </BottomDiv>
         </>
     );

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const DropDownList = styled("ul")`
     width: 100%;
@@ -14,6 +15,14 @@ const DropDownList = styled("ul")`
 
     font-size: ${(props) => props.theme.fontSize.sm};
     font-weight: 500;
+
+    ${media.mobile} {
+        max-width: calc(100vw - 32px);
+        max-height: min(320px, 50vh);
+        overflow-y: auto;
+        overscroll-behavior: contain;
+    }
+
     &:first-child {
         padding-top: 0.8em;
     }
@@ -24,6 +33,12 @@ const ListItem = styled("li")`
     margin-bottom: 0.8em;
     padding: 10px 20px;
     cursor: pointer;
+
+    ${media.mobile} {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
     &:hover {
         background: ${(props) => props.theme.color.bgColor};
         color: ${(props) => props.theme.color.wh};

--- a/src/components/common/HeaderNav.tsx
+++ b/src/components/common/HeaderNav.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 
 import { GetRoleAuthorization } from "../../functions/authFunctions";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import useFetch from "../../hooks/useFetch";
 import {
@@ -28,6 +28,215 @@ const FixedDiv = styled(FlexDiv)`
     position: fixed;
     top: 0;
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const NavInner = styled(FlexDiv)`
+    width: 1170px;
+    max-width: 1170px;
+
+    ${media.desktop} {
+        width: 100%;
+        max-width: 1170px;
+        padding: 0 24px;
+    }
+
+    ${media.mobile} {
+        padding: 0 16px;
+    }
+`;
+
+const Logo = styled(Div)`
+    width: 200px;
+    height: 75px;
+
+    ${media.desktop} {
+        width: 170px;
+    }
+
+    ${media.mobile} {
+        width: 150px;
+        height: 64px;
+    }
+`;
+
+const DesktopNav = styled(FlexDiv)`
+    ${media.tablet} {
+        display: none;
+    }
+`;
+
+const MobileMenuButton = styled.button<{ $isScrolled: boolean }>`
+    display: none;
+    width: 40px;
+    height: 40px;
+    padding: 8px;
+    border: 0;
+    background: transparent;
+    color: ${({ $isScrolled }) => ($isScrolled ? theme.color.textColor : theme.color.wh)};
+    cursor: pointer;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+
+    span {
+        display: block;
+        width: 22px;
+        height: 2px;
+        border-radius: 2px;
+        background-color: currentColor;
+    }
+
+    ${media.tablet} {
+        display: flex;
+    }
+`;
+
+const MobileMenuLayer = styled.div`
+    display: none;
+
+    ${media.tablet} {
+        display: block;
+        position: fixed;
+        top: 73px;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 4;
+    }
+`;
+
+const MobileMenuBackdrop = styled.button`
+    position: absolute;
+    top: 0;
+    right: min(420px, 88vw);
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background-color: rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+
+    ${media.mobile} {
+        right: min(360px, 88vw);
+    }
+`;
+
+const MobileMenuPanel = styled.aside`
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: min(420px, 88vw);
+    height: 100%;
+    padding: 24px;
+    background-color: ${theme.color.wh};
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    ${media.mobile} {
+        width: min(360px, 88vw);
+        padding: 20px 16px;
+    }
+`;
+
+const MobileMenuHeader = styled(FlexDiv)`
+    width: 100%;
+    padding-bottom: 16px;
+    border-bottom: 1px solid ${theme.color.border};
+`;
+
+const MobileMenuTitle = styled(P)`
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.lg};
+    font-weight: 800;
+    letter-spacing: 1px;
+`;
+
+const MobileMenuCloseButton = styled.button`
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.border};
+    }
+`;
+
+const MobileMenuGroup = styled.div`
+    width: 100%;
+    padding: 20px 0;
+    border-bottom: 1px solid ${theme.color.border};
+    white-space: normal;
+`;
+
+const MobileGroupName = styled(P)`
+    margin-bottom: 8px;
+    color: ${theme.color.textColor};
+    font-weight: 800;
+    letter-spacing: 1px;
+    white-space: normal;
+    overflow: visible;
+`;
+
+const MobileMenuItem = styled.button`
+    display: block;
+    width: 100%;
+    padding: 11px 8px;
+    border: 0;
+    border-radius: 4px;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.sm};
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.bgColor};
+        color: ${theme.color.wh};
+    }
+`;
+
+const MobileAccount = styled.div`
+    width: 100%;
+    padding-top: 20px;
+    white-space: normal;
+`;
+
+const MobileProfileButton = styled.button`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 12px;
+    padding: 8px;
+    border: 0;
+    border-radius: 4px;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.sm};
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.border};
+    }
+`;
+
+const MobileAccountButton = styled(MobileMenuItem)`
+    margin-top: 8px;
+    color: ${theme.color.textColor};
+    font-weight: 800;
 `;
 
 interface Group {
@@ -58,6 +267,8 @@ const HeaderNav = () => {
     const setCurrentMenuId = useSetRecoilState(menuId);
     const pathNameInfo = location.pathname.substring(1).split("/");
     const [isNotLogin, setIsNotLogin] = useRecoilState(failRefreshing);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const mobileMenuId = useId();
 
     let titleId = 0;
 
@@ -152,6 +363,7 @@ const HeaderNav = () => {
 
     const movePage = (url: string) => {
         navigate(`/${url}`);
+        setIsMobileMenuOpen(false);
     };
 
     const menuClickEvent = (url: string, givenName: string, givenDescription: string) => {
@@ -177,6 +389,7 @@ const HeaderNav = () => {
         } else {
             navigate(`/${url}`);
             setTitle({ ...title, name: givenName, description: givenDescription });
+            setIsMobileMenuOpen(false);
         }
     };
 
@@ -186,6 +399,7 @@ const HeaderNav = () => {
             setRole("logout");
             document.cookie = "ibas_refresh" + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;";
             navigate("/");
+            setIsMobileMenuOpen(false);
         }
     };
 
@@ -258,6 +472,45 @@ const HeaderNav = () => {
         };
     }, []);
 
+    useEffect(() => {
+        setIsMobileMenuOpen(false);
+    }, [location.pathname]);
+
+    useEffect(() => {
+        const desktopMedia = window.matchMedia(
+            `(min-width: ${Number.parseInt(theme.breakpoints.tablet, 10) + 1}px)`
+        );
+        const closeOnDesktop = (event: MediaQueryListEvent) => {
+            if (event.matches) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        desktopMedia.addEventListener("change", closeOnDesktop);
+        return () => desktopMedia.removeEventListener("change", closeOnDesktop);
+    }, []);
+
+    useEffect(() => {
+        if (!isMobileMenuOpen) {
+            return;
+        }
+
+        const originalOverflow = document.body.style.overflow;
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        document.body.style.overflow = "hidden";
+        window.addEventListener("keydown", closeOnEscape);
+
+        return () => {
+            document.body.style.overflow = originalOverflow;
+            window.removeEventListener("keydown", closeOnEscape);
+        };
+    }, [isMobileMenuOpen]);
+
     return (
         <>
             <FixedDiv
@@ -267,15 +520,15 @@ const HeaderNav = () => {
                 $backgroundColor={scrollPosition < 100 ? "none" : "wh"}
                 $borderB={`0.1px solid ${theme.color.whlayer}`}
             >
-                <FlexDiv width="1170px" $maxWidth="1170px" $justifycontent="space-between">
-                    <Div width="200px" height="75px" $pointer onClick={() => movePage("")}>
+                <NavInner $justifycontent="space-between">
+                    <Logo $pointer onClick={() => movePage("")}>
                         {scrollPosition < 100 ? (
                             <Img src="/images/logo_white.png" />
                         ) : (
                             <Img src="/images/logo_purple.png" />
                         )}
-                    </Div>
-                    <FlexDiv>
+                    </Logo>
+                    <DesktopNav>
                         <FlexDiv>
                             <FlexDiv>
                                 {nav &&
@@ -487,9 +740,128 @@ const HeaderNav = () => {
                                 </FlexDiv> */}
                             </FlexDiv>
                         )}
-                    </FlexDiv>
-                </FlexDiv>
+                    </DesktopNav>
+                    <MobileMenuButton
+                        type="button"
+                        $isScrolled={scrollPosition >= 100}
+                        aria-label="메뉴 열기"
+                        aria-expanded={isMobileMenuOpen}
+                        aria-controls={mobileMenuId}
+                        onClick={() => setIsMobileMenuOpen(true)}
+                    >
+                        <span />
+                        <span />
+                        <span />
+                    </MobileMenuButton>
+                </NavInner>
             </FixedDiv>
+            {isMobileMenuOpen && (
+                <MobileMenuLayer>
+                    <MobileMenuBackdrop
+                        type="button"
+                        aria-label="메뉴 배경을 눌러 닫기"
+                        onClick={() => setIsMobileMenuOpen(false)}
+                    />
+                    <MobileMenuPanel id={mobileMenuId} aria-label="모바일 메뉴">
+                        <MobileMenuHeader $justifycontent="space-between">
+                            <MobileMenuTitle>MENU</MobileMenuTitle>
+                            <MobileMenuCloseButton
+                                type="button"
+                                aria-label="메뉴 닫기"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                            >
+                                ×
+                            </MobileMenuCloseButton>
+                        </MobileMenuHeader>
+                        {nav &&
+                            Object.values(nav)
+                                .filter((item: any) => !HIDDEN_NAV_GROUPS.includes(item.groupName))
+                                .map((item: any, idx: number) => (
+                                    <MobileMenuGroup key={`mobileGroup${idx}`}>
+                                        <MobileGroupName>{item.groupName}</MobileGroupName>
+                                        {item.menuList &&
+                                            Object.values(item.menuList)
+                                                .filter((element: any) => !HIDDEN_BOARD_URLS.includes(element.url))
+                                                .map((element: any, menuIdx: number) => {
+                                                    if (
+                                                        element.url === "board/executive" &&
+                                                        isAuthorizedOverSecretary
+                                                    ) {
+                                                        return (
+                                                            <MobileMenuItem
+                                                                type="button"
+                                                                key={`mobileMenu${menuIdx}`}
+                                                                onClick={() =>
+                                                                    menuClickEvent(
+                                                                        element.url,
+                                                                        element.name,
+                                                                        element.description
+                                                                    )
+                                                                }
+                                                            >
+                                                                {element.name}
+                                                            </MobileMenuItem>
+                                                        );
+                                                    } else if (element.url !== "board/executive") {
+                                                        return (
+                                                            <MobileMenuItem
+                                                                type="button"
+                                                                key={`mobileMenu${menuIdx}`}
+                                                                onClick={() =>
+                                                                    menuClickEvent(
+                                                                        element.url,
+                                                                        element.name,
+                                                                        element.description
+                                                                    )
+                                                                }
+                                                            >
+                                                                {element.name}
+                                                            </MobileMenuItem>
+                                                        );
+                                                    }
+                                                    return null;
+                                                })}
+                                    </MobileMenuGroup>
+                                ))}
+                        <MobileAccount>
+                            {access !== "default" && access !== "signing" && (
+                                <MobileProfileButton type="button" onClick={() => movePage("myInfo")}>
+                                    <FlexDiv
+                                        width="35px"
+                                        height="35px"
+                                        $border="2px solid"
+                                        $borderColor={
+                                            isAuthorizedOverBasic
+                                                ? "success"
+                                                : isAuthorizedOverDeactivate
+                                                ? "yellow"
+                                                : "red"
+                                        }
+                                        radius={100}
+                                        overflow="hidden"
+                                    >
+                                        <Img
+                                            src={info?.picture}
+                                            $objectFit="cover"
+                                            alt="현재 브라우저에서 지원하지 않는 형태 입니다. "
+                                        />
+                                    </FlexDiv>
+                                    <span>{info?.name}</span>
+                                </MobileProfileButton>
+                            )}
+                            {access === "default" || access === "signing" ? (
+                                <MobileAccountButton type="button" onClick={() => movePage("login")}>
+                                    LOG IN
+                                </MobileAccountButton>
+                            ) : (
+                                <MobileAccountButton type="button" onClick={() => logoutClickEvent()}>
+                                    LOG OUT
+                                </MobileAccountButton>
+                            )}
+                        </MobileAccount>
+                    </MobileMenuPanel>
+                </MobileMenuLayer>
+            )}
         </>
     );
 };

--- a/src/components/common/HeaderTitle.tsx
+++ b/src/components/common/HeaderTitle.tsx
@@ -13,17 +13,83 @@ import useFetch from "../../hooks/useFetch";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import { H1 } from "../../styles/assets/H";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const HeaderImgDiv = styled(Div)`
     background-image: url("/images/board-name-img.jpg");
     background-size: cover;
     position: relative;
+    height: 423px;
+
+    ${media.tablet} {
+        height: 320px;
+    }
+
+    ${media.mobile} {
+        height: 240px;
+    }
 `;
 
 const HeaderHDiv = styled(FlexDiv)`
     position: absolute;
     top: 0;
     left: 0;
+    height: 423px;
+
+    ${media.tablet} {
+        height: 320px;
+    }
+
+    ${media.mobile} {
+        height: 240px;
+    }
+`;
+
+const TitleContent = styled.div`
+    width: 100%;
+    max-width: 1170px;
+    padding: 0 24px;
+    text-align: center;
+    white-space: normal;
+
+    & > div {
+        width: 100%;
+        white-space: normal;
+    }
+
+    ${media.mobile} {
+        padding: 0 16px;
+    }
+`;
+
+const TitleName = styled(H1)`
+    white-space: normal;
+    overflow-wrap: anywhere;
+
+    ${media.tablet} {
+        font-size: 36px;
+    }
+
+    ${media.mobile} {
+        font-size: 28px;
+        line-height: 1.25;
+    }
+`;
+
+const TitleDescription = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+
+    ${media.tablet} {
+        font-size: 16px;
+        line-height: 1.5;
+    }
+
+    ${media.mobile} {
+        font-size: 14px;
+    }
 `;
 
 const HeaderTitle = () => {
@@ -142,23 +208,23 @@ const HeaderTitle = () => {
 
     return (
         <>
-            <HeaderHDiv $zIndex={2} width="100%" height="423px" $backgroundColor="bklayer" direction="column">
+            <HeaderHDiv $zIndex={2} width="100%" $backgroundColor="bklayer" direction="column">
                 {title && (
-                    <>
+                    <TitleContent>
                         <Div $margin="0 0 20px 0">
-                            <H1 color="wh" fontWeight={700} fontSize="xxxl">
+                            <TitleName color="wh" fontWeight={700} fontSize="xxxl">
                                 {title.name}
-                            </H1>
+                            </TitleName>
                         </Div>
                         <Div>
-                            <P color="grey3" fontWeight={300} fontSize="lg">
+                            <TitleDescription color="grey3" fontWeight={300} fontSize="lg">
                                 {title.description}
-                            </P>
+                            </TitleDescription>
                         </Div>
-                    </>
+                    </TitleContent>
                 )}
             </HeaderHDiv>
-            <HeaderImgDiv width="100%" height="423px" />
+            <HeaderImgDiv width="100%" />
         </>
     );
 };

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -4,7 +4,51 @@ import { paginationPropsInterface } from "../../types/TypeCommon";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
+import styled from "styled-components";
+
+const PaginationContainer = styled(FlexDiv)`
+    ${media.mobile} {
+        gap: 4px 0;
+        padding: 16px 0;
+    }
+`;
+
+const PageButton = styled(FlexDiv)`
+    width: 45px;
+    height: 45px;
+    margin: 5px;
+    padding: 5px;
+
+    ${media.mobile} {
+        width: 36px;
+        height: 36px;
+        margin: 2px;
+        padding: 4px;
+    }
+`;
+
+const NavigationButtonWrapper = styled(Div)`
+    margin: 0 8px;
+
+    ${media.mobile} {
+        margin: 0 2px;
+    }
+`;
+
+const NavigationButton = styled(FlexDiv)`
+    width: 45px;
+    height: 45px;
+    margin: 5px;
+    padding: 5px;
+
+    ${media.mobile} {
+        width: 36px;
+        height: 36px;
+        margin: 0;
+        padding: 4px;
+    }
+`;
 
 const Pagination = (props: paginationPropsInterface) => {
     const { totalPage, fetchUrl, search, size, token, paginationFetch } = props;
@@ -22,17 +66,13 @@ const Pagination = (props: paginationPropsInterface) => {
         let pageNumList = [];
         for (let i = startPage; i < startPage + 5 && i <= totalPage; i++) {
             pageNumList.push(
-                <FlexDiv
+                <PageButton
                     onClick={() => {
                         setCurrentPage(i);
                         setPageChange(true);
                     }}
                     key={`page${i}`}
                     display="flex"
-                    width="45px"
-                    height="45px"
-                    $padding="5px"
-                    $margin="5px"
                     $pointer
                     $backgroundColor={i !== currentPage ? "wh" : "bgColor"}
                     $border={`2px solid ${theme.color.bk}`}
@@ -43,7 +83,7 @@ const Pagination = (props: paginationPropsInterface) => {
                             {i}
                         </P>
                     </Div>
-                </FlexDiv>
+                </PageButton>
             );
         }
 
@@ -82,10 +122,10 @@ const Pagination = (props: paginationPropsInterface) => {
     }, [pageChange]);
 
     return (
-        <FlexDiv width="100%" $padding="20px 0">
+        <PaginationContainer width="100%" $padding="20px 0">
             {totalPage !== 1 && (
                 <>
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setAllLeftHovered(true)}
                         onMouseLeave={() => setAllLeftHovered(false)}
                         onClick={() => {
@@ -95,13 +135,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={allLeftHovered ? "bgColor" : "wh"}
                             $pointer
@@ -113,10 +148,10 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/angles-left_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
 
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setLeftHovered(true)}
                         onMouseLeave={() => setLeftHovered(false)}
                         onClick={() => {
@@ -126,13 +161,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={leftHovered ? "bgColor" : "wh"}
                             $pointer
@@ -144,8 +174,8 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/arrow-left_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
                 </>
             )}
 
@@ -153,7 +183,7 @@ const Pagination = (props: paginationPropsInterface) => {
 
             {totalPage !== 1 && (
                 <>
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setRightHovered(true)}
                         onMouseLeave={() => setRightHovered(false)}
                         onClick={() => {
@@ -163,13 +193,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={rightHovered ? "bgColor" : "wh"}
                             $pointer
@@ -181,10 +206,10 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/arrow-right_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
 
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setAllRightHovered(true)}
                         onMouseLeave={() => setAllRightHovered(false)}
                         onClick={() => {
@@ -192,13 +217,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             setPageChange(true);
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={allRightHovered ? "bgColor" : "wh"}
                             $pointer
@@ -210,11 +230,11 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/angles-right_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
                 </>
             )}
-        </FlexDiv>
+        </PaginationContainer>
     );
 };
 

--- a/src/styles/assets/Div.ts
+++ b/src/styles/assets/Div.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { DefaultTheme } from "styled-components/dist/types";
+import { media } from "../theme";
 
 interface DivStyle {
     theme: DefaultTheme;
@@ -97,12 +98,34 @@ const Container = styled(FlexDiv)`
     width: 80%;
     max-width: 80%;
     padding: 5% 0;
+
+    ${media.tablet} {
+        width: calc(100% - 48px);
+        max-width: calc(100% - 48px);
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 100%;
+        padding: 5% 16px;
+    }
 `;
 
 const DetailContainer = styled(Div)`
     width: 800px;
     max-width: 800px;
     padding: 5% 0;
+
+    ${media.tablet} {
+        width: calc(100% - 48px);
+        max-width: calc(100% - 48px);
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 100%;
+        padding: 5% 16px;
+    }
 `;
 
 const InputLabel = styled.label<DivStyle>`


### PR DESCRIPTION
## 개요

> 공통 레이아웃·내비게이션에 태블릿·모바일 반응형 스타일을 적용합니다. 기존 데스크톱 UI와 기능은 유지하고, `#617` 범위의 공통 영역만 대응합니다.

## 변경 사항

- `Container` / `DetailContainer` 반응형 너비·패딩 적용
- 헤더 내비게이션 모바일 메뉴 및 반응형 레이아웃 추가
- 헤더 타이틀 영역 높이·타이포 반응형 조정
- 푸터 반응형 레이아웃 적용
- 드롭다운 모바일 오버플로우·텍스트 줄바꿈 수정
- 페이지네이션 모바일 버튼 크기·배치 수정

## 변경 유형

- [x] `feat` — 새로운 기능
- [ ] `fix` — 버그 수정
- [x] `design` — UI · 스타일 변경
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `docs` — 문서
- [ ] `chore` — 빌드 설정, 패키지 변경
- [ ] `ci` — CI/CD 설정 변경
- [ ] `revert` — 이전 커밋 되돌리기

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해 주세요 -->

resolves: #617

## 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before / After 스크린샷을 첨부해 주세요 -->

| Before | After |
|--------|-------|
|        |       |

## 체크리스트

- [x] `upstream/dev` 기준으로 브랜치를 만들었다
- [ ] 빌드가 정상적으로 된다 (`npm run build`)
- [ ] ESLint 에러가 없다
- [ ] 기존 기능이 정상 작동한다
- [x] WIP 커밋을 정리했다 (`git rebase -i`)
- [ ] 불필요한 `console.log`와 주석 처리된 코드를 제거했다