### PR TITLE
[feat/#618] 홈 및 회원 화면 반응형 구현

### DIFF
--- a/src/components/common/Bottom.tsx
+++ b/src/components/common/Bottom.tsx
@@ -9,6 +9,7 @@ import A from "../../styles/assets/A";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const BottomDiv = styled(FlexDiv)`
     background-image: url("/images/bottom.jpg");
@@ -16,6 +17,117 @@ const BottomDiv = styled(FlexDiv)`
     background-position: center center;
     background-size: cover;
     position: relative;
+
+    ${media.tablet} {
+        height: auto;
+    }
+`;
+
+const BottomContent = styled(FlexDiv)`
+    width: 100%;
+    justify-content: space-around;
+    padding: 20px 0;
+
+    ${media.tablet} {
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 32px 24px;
+    }
+
+    ${media.mobile} {
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        padding: 40px 16px 32px;
+    }
+`;
+
+const FooterLogo = styled(Div)`
+    width: 350px;
+
+    ${media.desktop} {
+        width: 28%;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 240px;
+    }
+`;
+
+const ContactColumn = styled(FlexDiv)`
+    width: 350px;
+    height: 180px;
+
+    ${media.desktop} {
+        width: 38%;
+    }
+
+    ${media.tablet} {
+        height: auto;
+        gap: 14px;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 360px;
+        align-items: flex-start;
+    }
+`;
+
+const ContactRow = styled(FlexDiv)`
+    width: 100%;
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+
+    & > div:last-child {
+        min-width: 0;
+        white-space: normal;
+    }
+`;
+
+const ContactText = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.5;
+`;
+
+const Terms = styled(FlexDiv)`
+    width: 100%;
+    padding: 20px;
+    border: 1px solid ${props => props.theme.color.bk};
+
+    ${media.mobile} {
+        gap: 8px 0;
+        padding: 18px 16px;
+    }
+`;
+
+const Term = styled(FlexDiv)`
+    white-space: normal;
+
+    ${media.mobile} {
+        justify-content: center;
+    }
+`;
+
+const Credits = styled(FlexDiv)`
+    height: 70px;
+
+    p {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        text-align: center;
+    }
+
+    ${media.mobile} {
+        height: auto;
+        gap: 8px;
+        padding: 20px 16px 28px;
+    }
 `;
 
 const Bottom = () => {
@@ -42,69 +154,67 @@ const Bottom = () => {
     return (
         <>
             <BottomDiv width="100%" height="350px">
-                <FlexDiv width="100%" $justifycontent="space-around" $padding="20px 0">
-                    <Div width="350px">
+                <BottomContent>
+                    <FooterLogo>
                         <Img src="/images/logo_white.png" />
-                    </Div>
-                    <FlexDiv
+                    </FooterLogo>
+                    <ContactColumn
                         direction="column"
                         $justifycontent="space-around"
                         $alignitems="start"
-                        width="350px"
-                        height="180px"
                     >
                         <Div>
                             <P color="wh" fontWeight={800} fontSize="lg">
                                 Contact Us
                             </P>
                         </Div>
-                        <FlexDiv>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/user_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.name}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/location_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     인하대학교 22212 인천광역시 미추홀구 인하로 100
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/phone_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.phoneNumber}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                        <FlexDiv>
+                        </ContactRow>
+                        <ContactRow>
                             <Div width="17px" height="15px" $margin="0 5px 0 0">
                                 <Img src="/images/envelope_white.svg" />
                             </Div>
                             <Div>
-                                <P fontSize="sm" color="wh">
+                                <ContactText fontSize="sm" color="wh">
                                     {chief?.email}
-                                </P>
+                                </ContactText>
                             </Div>
-                        </FlexDiv>
-                    </FlexDiv>
-                    <Div width="350px">
+                        </ContactRow>
+                    </ContactColumn>
+                    <FooterLogo>
                         <Img src="/images/inha-en-logo_white.png" />
-                    </Div>
-                </FlexDiv>
-                <FlexDiv width="100%" $padding="20px" $border="1px solid" $borderColor="bk">
-                    <FlexDiv $pointer>
+                    </FooterLogo>
+                </BottomContent>
+                <Terms>
+                    <Term $pointer>
                         <Div>
                             <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(1)}>
                                 제3자에 관한 개인정보 이용제공 동의 약관
@@ -113,8 +223,8 @@ const Bottom = () => {
                         <Div $margin="0 5px">
                             <P color="wh">·</P>
                         </Div>
-                    </FlexDiv>
-                    <FlexDiv $pointer>
+                    </Term>
+                    <Term $pointer>
                         <Div>
                             <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(2)}>
                                 동아리 회칙
@@ -123,14 +233,14 @@ const Bottom = () => {
                         <Div $margin="0 5px">
                             <P color="wh">·</P>
                         </Div>
-                    </FlexDiv>
-                    <FlexDiv $pointer>
+                    </Term>
+                    <Term $pointer>
                         <A color="wh" fontSize="sm" $hoverColor="grey2" onClick={() => moveRule(3)}>
                             홈페이지 이용약관
                         </A>
-                    </FlexDiv>
-                </FlexDiv>
-                <FlexDiv direction="column" $justifycontent="space-around" $padding="20px 0 " height="70px">
+                    </Term>
+                </Terms>
+                <Credits direction="column" $justifycontent="space-around" $padding="20px 0 ">
                     <Div>
                         <P color="wh" fontSize="xs">
                             2021 Developed By 양태영, 신승연, 김채림, 윤예진, 유동현
@@ -141,7 +251,7 @@ const Bottom = () => {
                             2024 Developed By 조승현, 윤예진, 송민석
                         </P>
                     </Div>
-                </FlexDiv>
+                </Credits>
             </BottomDiv>
         </>
     );

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const DropDownList = styled("ul")`
     width: 100%;
@@ -14,6 +15,14 @@ const DropDownList = styled("ul")`
 
     font-size: ${(props) => props.theme.fontSize.sm};
     font-weight: 500;
+
+    ${media.mobile} {
+        max-width: calc(100vw - 32px);
+        max-height: min(320px, 50vh);
+        overflow-y: auto;
+        overscroll-behavior: contain;
+    }
+
     &:first-child {
         padding-top: 0.8em;
     }
@@ -24,6 +33,12 @@ const ListItem = styled("li")`
     margin-bottom: 0.8em;
     padding: 10px 20px;
     cursor: pointer;
+
+    ${media.mobile} {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
     &:hover {
         background: ${(props) => props.theme.color.bgColor};
         color: ${(props) => props.theme.color.wh};

--- a/src/components/common/HeaderNav.tsx
+++ b/src/components/common/HeaderNav.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 
 import { GetRoleAuthorization } from "../../functions/authFunctions";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import useFetch from "../../hooks/useFetch";
 import {
@@ -28,6 +28,215 @@ const FixedDiv = styled(FlexDiv)`
     position: fixed;
     top: 0;
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const NavInner = styled(FlexDiv)`
+    width: 1170px;
+    max-width: 1170px;
+
+    ${media.desktop} {
+        width: 100%;
+        max-width: 1170px;
+        padding: 0 24px;
+    }
+
+    ${media.mobile} {
+        padding: 0 16px;
+    }
+`;
+
+const Logo = styled(Div)`
+    width: 200px;
+    height: 75px;
+
+    ${media.desktop} {
+        width: 170px;
+    }
+
+    ${media.mobile} {
+        width: 150px;
+        height: 64px;
+    }
+`;
+
+const DesktopNav = styled(FlexDiv)`
+    ${media.tablet} {
+        display: none;
+    }
+`;
+
+const MobileMenuButton = styled.button<{ $isScrolled: boolean }>`
+    display: none;
+    width: 40px;
+    height: 40px;
+    padding: 8px;
+    border: 0;
+    background: transparent;
+    color: ${({ $isScrolled }) => ($isScrolled ? theme.color.textColor : theme.color.wh)};
+    cursor: pointer;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+
+    span {
+        display: block;
+        width: 22px;
+        height: 2px;
+        border-radius: 2px;
+        background-color: currentColor;
+    }
+
+    ${media.tablet} {
+        display: flex;
+    }
+`;
+
+const MobileMenuLayer = styled.div`
+    display: none;
+
+    ${media.tablet} {
+        display: block;
+        position: fixed;
+        top: 73px;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 4;
+    }
+`;
+
+const MobileMenuBackdrop = styled.button`
+    position: absolute;
+    top: 0;
+    right: min(420px, 88vw);
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background-color: rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+
+    ${media.mobile} {
+        right: min(360px, 88vw);
+    }
+`;
+
+const MobileMenuPanel = styled.aside`
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: min(420px, 88vw);
+    height: 100%;
+    padding: 24px;
+    background-color: ${theme.color.wh};
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    ${media.mobile} {
+        width: min(360px, 88vw);
+        padding: 20px 16px;
+    }
+`;
+
+const MobileMenuHeader = styled(FlexDiv)`
+    width: 100%;
+    padding-bottom: 16px;
+    border-bottom: 1px solid ${theme.color.border};
+`;
+
+const MobileMenuTitle = styled(P)`
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.lg};
+    font-weight: 800;
+    letter-spacing: 1px;
+`;
+
+const MobileMenuCloseButton = styled.button`
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.border};
+    }
+`;
+
+const MobileMenuGroup = styled.div`
+    width: 100%;
+    padding: 20px 0;
+    border-bottom: 1px solid ${theme.color.border};
+    white-space: normal;
+`;
+
+const MobileGroupName = styled(P)`
+    margin-bottom: 8px;
+    color: ${theme.color.textColor};
+    font-weight: 800;
+    letter-spacing: 1px;
+    white-space: normal;
+    overflow: visible;
+`;
+
+const MobileMenuItem = styled.button`
+    display: block;
+    width: 100%;
+    padding: 11px 8px;
+    border: 0;
+    border-radius: 4px;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.sm};
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.bgColor};
+        color: ${theme.color.wh};
+    }
+`;
+
+const MobileAccount = styled.div`
+    width: 100%;
+    padding-top: 20px;
+    white-space: normal;
+`;
+
+const MobileProfileButton = styled.button`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 12px;
+    padding: 8px;
+    border: 0;
+    border-radius: 4px;
+    background-color: transparent;
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.sm};
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background-color: ${theme.color.border};
+    }
+`;
+
+const MobileAccountButton = styled(MobileMenuItem)`
+    margin-top: 8px;
+    color: ${theme.color.textColor};
+    font-weight: 800;
 `;
 
 interface Group {
@@ -58,6 +267,8 @@ const HeaderNav = () => {
     const setCurrentMenuId = useSetRecoilState(menuId);
     const pathNameInfo = location.pathname.substring(1).split("/");
     const [isNotLogin, setIsNotLogin] = useRecoilState(failRefreshing);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const mobileMenuId = useId();
 
     let titleId = 0;
 
@@ -152,6 +363,7 @@ const HeaderNav = () => {
 
     const movePage = (url: string) => {
         navigate(`/${url}`);
+        setIsMobileMenuOpen(false);
     };
 
     const menuClickEvent = (url: string, givenName: string, givenDescription: string) => {
@@ -177,6 +389,7 @@ const HeaderNav = () => {
         } else {
             navigate(`/${url}`);
             setTitle({ ...title, name: givenName, description: givenDescription });
+            setIsMobileMenuOpen(false);
         }
     };
 
@@ -186,6 +399,7 @@ const HeaderNav = () => {
             setRole("logout");
             document.cookie = "ibas_refresh" + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;";
             navigate("/");
+            setIsMobileMenuOpen(false);
         }
     };
 
@@ -258,6 +472,45 @@ const HeaderNav = () => {
         };
     }, []);
 
+    useEffect(() => {
+        setIsMobileMenuOpen(false);
+    }, [location.pathname]);
+
+    useEffect(() => {
+        const desktopMedia = window.matchMedia(
+            `(min-width: ${Number.parseInt(theme.breakpoints.tablet, 10) + 1}px)`
+        );
+        const closeOnDesktop = (event: MediaQueryListEvent) => {
+            if (event.matches) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        desktopMedia.addEventListener("change", closeOnDesktop);
+        return () => desktopMedia.removeEventListener("change", closeOnDesktop);
+    }, []);
+
+    useEffect(() => {
+        if (!isMobileMenuOpen) {
+            return;
+        }
+
+        const originalOverflow = document.body.style.overflow;
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        document.body.style.overflow = "hidden";
+        window.addEventListener("keydown", closeOnEscape);
+
+        return () => {
+            document.body.style.overflow = originalOverflow;
+            window.removeEventListener("keydown", closeOnEscape);
+        };
+    }, [isMobileMenuOpen]);
+
     return (
         <>
             <FixedDiv
@@ -267,15 +520,15 @@ const HeaderNav = () => {
                 $backgroundColor={scrollPosition < 100 ? "none" : "wh"}
                 $borderB={`0.1px solid ${theme.color.whlayer}`}
             >
-                <FlexDiv width="1170px" $maxWidth="1170px" $justifycontent="space-between">
-                    <Div width="200px" height="75px" $pointer onClick={() => movePage("")}>
+                <NavInner $justifycontent="space-between">
+                    <Logo $pointer onClick={() => movePage("")}>
                         {scrollPosition < 100 ? (
                             <Img src="/images/logo_white.png" />
                         ) : (
                             <Img src="/images/logo_purple.png" />
                         )}
-                    </Div>
-                    <FlexDiv>
+                    </Logo>
+                    <DesktopNav>
                         <FlexDiv>
                             <FlexDiv>
                                 {nav &&
@@ -487,9 +740,128 @@ const HeaderNav = () => {
                                 </FlexDiv> */}
                             </FlexDiv>
                         )}
-                    </FlexDiv>
-                </FlexDiv>
+                    </DesktopNav>
+                    <MobileMenuButton
+                        type="button"
+                        $isScrolled={scrollPosition >= 100}
+                        aria-label="메뉴 열기"
+                        aria-expanded={isMobileMenuOpen}
+                        aria-controls={mobileMenuId}
+                        onClick={() => setIsMobileMenuOpen(true)}
+                    >
+                        <span />
+                        <span />
+                        <span />
+                    </MobileMenuButton>
+                </NavInner>
             </FixedDiv>
+            {isMobileMenuOpen && (
+                <MobileMenuLayer>
+                    <MobileMenuBackdrop
+                        type="button"
+                        aria-label="메뉴 배경을 눌러 닫기"
+                        onClick={() => setIsMobileMenuOpen(false)}
+                    />
+                    <MobileMenuPanel id={mobileMenuId} aria-label="모바일 메뉴">
+                        <MobileMenuHeader $justifycontent="space-between">
+                            <MobileMenuTitle>MENU</MobileMenuTitle>
+                            <MobileMenuCloseButton
+                                type="button"
+                                aria-label="메뉴 닫기"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                            >
+                                ×
+                            </MobileMenuCloseButton>
+                        </MobileMenuHeader>
+                        {nav &&
+                            Object.values(nav)
+                                .filter((item: any) => !HIDDEN_NAV_GROUPS.includes(item.groupName))
+                                .map((item: any, idx: number) => (
+                                    <MobileMenuGroup key={`mobileGroup${idx}`}>
+                                        <MobileGroupName>{item.groupName}</MobileGroupName>
+                                        {item.menuList &&
+                                            Object.values(item.menuList)
+                                                .filter((element: any) => !HIDDEN_BOARD_URLS.includes(element.url))
+                                                .map((element: any, menuIdx: number) => {
+                                                    if (
+                                                        element.url === "board/executive" &&
+                                                        isAuthorizedOverSecretary
+                                                    ) {
+                                                        return (
+                                                            <MobileMenuItem
+                                                                type="button"
+                                                                key={`mobileMenu${menuIdx}`}
+                                                                onClick={() =>
+                                                                    menuClickEvent(
+                                                                        element.url,
+                                                                        element.name,
+                                                                        element.description
+                                                                    )
+                                                                }
+                                                            >
+                                                                {element.name}
+                                                            </MobileMenuItem>
+                                                        );
+                                                    } else if (element.url !== "board/executive") {
+                                                        return (
+                                                            <MobileMenuItem
+                                                                type="button"
+                                                                key={`mobileMenu${menuIdx}`}
+                                                                onClick={() =>
+                                                                    menuClickEvent(
+                                                                        element.url,
+                                                                        element.name,
+                                                                        element.description
+                                                                    )
+                                                                }
+                                                            >
+                                                                {element.name}
+                                                            </MobileMenuItem>
+                                                        );
+                                                    }
+                                                    return null;
+                                                })}
+                                    </MobileMenuGroup>
+                                ))}
+                        <MobileAccount>
+                            {access !== "default" && access !== "signing" && (
+                                <MobileProfileButton type="button" onClick={() => movePage("myInfo")}>
+                                    <FlexDiv
+                                        width="35px"
+                                        height="35px"
+                                        $border="2px solid"
+                                        $borderColor={
+                                            isAuthorizedOverBasic
+                                                ? "success"
+                                                : isAuthorizedOverDeactivate
+                                                ? "yellow"
+                                                : "red"
+                                        }
+                                        radius={100}
+                                        overflow="hidden"
+                                    >
+                                        <Img
+                                            src={info?.picture}
+                                            $objectFit="cover"
+                                            alt="현재 브라우저에서 지원하지 않는 형태 입니다. "
+                                        />
+                                    </FlexDiv>
+                                    <span>{info?.name}</span>
+                                </MobileProfileButton>
+                            )}
+                            {access === "default" || access === "signing" ? (
+                                <MobileAccountButton type="button" onClick={() => movePage("login")}>
+                                    LOG IN
+                                </MobileAccountButton>
+                            ) : (
+                                <MobileAccountButton type="button" onClick={() => logoutClickEvent()}>
+                                    LOG OUT
+                                </MobileAccountButton>
+                            )}
+                        </MobileAccount>
+                    </MobileMenuPanel>
+                </MobileMenuLayer>
+            )}
         </>
     );
 };

--- a/src/components/common/HeaderNav.tsx
+++ b/src/components/common/HeaderNav.tsx
@@ -145,9 +145,12 @@ const MobileMenuHeader = styled(FlexDiv)`
     width: 100%;
     padding-bottom: 16px;
     border-bottom: 1px solid ${theme.color.border};
+    flex-wrap: nowrap;
 `;
 
 const MobileMenuTitle = styled(P)`
+    flex: 1;
+    width: auto;
     color: ${theme.color.bk};
     font-size: ${theme.fontSize.lg};
     font-weight: 800;
@@ -155,6 +158,7 @@ const MobileMenuTitle = styled(P)`
 `;
 
 const MobileMenuCloseButton = styled.button`
+    flex: 0 0 40px;
     width: 40px;
     height: 40px;
     padding: 0;

--- a/src/components/common/HeaderTitle.tsx
+++ b/src/components/common/HeaderTitle.tsx
@@ -13,17 +13,83 @@ import useFetch from "../../hooks/useFetch";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import { H1 } from "../../styles/assets/H";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const HeaderImgDiv = styled(Div)`
     background-image: url("/images/board-name-img.jpg");
     background-size: cover;
     position: relative;
+    height: 423px;
+
+    ${media.tablet} {
+        height: 320px;
+    }
+
+    ${media.mobile} {
+        height: 240px;
+    }
 `;
 
 const HeaderHDiv = styled(FlexDiv)`
     position: absolute;
     top: 0;
     left: 0;
+    height: 423px;
+
+    ${media.tablet} {
+        height: 320px;
+    }
+
+    ${media.mobile} {
+        height: 240px;
+    }
+`;
+
+const TitleContent = styled.div`
+    width: 100%;
+    max-width: 1170px;
+    padding: 0 24px;
+    text-align: center;
+    white-space: normal;
+
+    & > div {
+        width: 100%;
+        white-space: normal;
+    }
+
+    ${media.mobile} {
+        padding: 0 16px;
+    }
+`;
+
+const TitleName = styled(H1)`
+    white-space: normal;
+    overflow-wrap: anywhere;
+
+    ${media.tablet} {
+        font-size: 36px;
+    }
+
+    ${media.mobile} {
+        font-size: 28px;
+        line-height: 1.25;
+    }
+`;
+
+const TitleDescription = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+
+    ${media.tablet} {
+        font-size: 16px;
+        line-height: 1.5;
+    }
+
+    ${media.mobile} {
+        font-size: 14px;
+    }
 `;
 
 const HeaderTitle = () => {
@@ -142,23 +208,23 @@ const HeaderTitle = () => {
 
     return (
         <>
-            <HeaderHDiv $zIndex={2} width="100%" height="423px" $backgroundColor="bklayer" direction="column">
+            <HeaderHDiv $zIndex={2} width="100%" $backgroundColor="bklayer" direction="column">
                 {title && (
-                    <>
+                    <TitleContent>
                         <Div $margin="0 0 20px 0">
-                            <H1 color="wh" fontWeight={700} fontSize="xxxl">
+                            <TitleName color="wh" fontWeight={700} fontSize="xxxl">
                                 {title.name}
-                            </H1>
+                            </TitleName>
                         </Div>
                         <Div>
-                            <P color="grey3" fontWeight={300} fontSize="lg">
+                            <TitleDescription color="grey3" fontWeight={300} fontSize="lg">
                                 {title.description}
-                            </P>
+                            </TitleDescription>
                         </Div>
-                    </>
+                    </TitleContent>
                 )}
             </HeaderHDiv>
-            <HeaderImgDiv width="100%" height="423px" />
+            <HeaderImgDiv width="100%" />
         </>
     );
 };

--- a/src/components/common/HonorSlide.tsx
+++ b/src/components/common/HonorSlide.tsx
@@ -2,15 +2,70 @@ import { honorDataInterface } from "../../types/ibas/TypeIBAS";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import styled from "styled-components";
+import { media } from "../../styles/theme";
 
 interface HonorSlideProps {
     honors: honorDataInterface;
     small?: boolean;
 }
 
+const Card = styled(Div)<{ $small?: boolean }>`
+    flex: 0 1 350px;
+
+    ${media.tablet} {
+        width: calc(100% - 32px);
+        max-width: 350px;
+        margin: ${({ $small }) => ($small ? "16px" : "0 auto")};
+        padding: 26px;
+    }
+
+    ${media.mobile} {
+        width: calc(100vw - 48px);
+        height: auto;
+        min-height: 390px;
+        margin: ${({ $small }) => ($small ? "12px auto" : "0 auto")};
+        padding: 24px 20px;
+    }
+`;
+
+const ProfileImage = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 7em;
+        height: 7em;
+    }
+`;
+
+const CardBody = styled(Div)`
+    ${media.mobile} {
+        height: auto;
+        max-height: 170px;
+    }
+`;
+
+const ContactRow = styled(FlexDiv)`
+    min-width: 0;
+`;
+
+const ContactIcon = styled(FlexDiv)`
+    flex: 0 0 15px;
+`;
+
+const ContactText = styled(FlexDiv)`
+    min-width: 0;
+
+    p {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        overflow-wrap: anywhere;
+    }
+`;
+
 const HonorSlide: React.FC<HonorSlideProps> = ({ honors, small }) => {
     return (
-        <Div
+        <Card
+            $small={small}
             radius={10}
             $backgroundColor="wh"
             width="350px"
@@ -19,7 +74,7 @@ const HonorSlide: React.FC<HonorSlideProps> = ({ honors, small }) => {
             $margin={small ? "0 20px" : "0 10%"}
         >
             <FlexDiv direction="column" $margin="0 0 20px 0" width="100%">
-                <FlexDiv
+                <ProfileImage
                     width="8em"
                     height="8em"
                     $border="4px solid"
@@ -30,7 +85,7 @@ const HonorSlide: React.FC<HonorSlideProps> = ({ honors, small }) => {
                     <FlexDiv width="100%" height="100%" radius={100} overflow="hidden">
                         <Img src={honors.picture} $objectFit="cover" />
                     </FlexDiv>
-                </FlexDiv>
+                </ProfileImage>
                 <FlexDiv direction="column" $justifycontent="space-around" $margin="10px 0 0 0" height="50px">
                     <FlexDiv $justifycontent="start">
                         <P fontSize="sm" color="textColor" fontWeight={700}>
@@ -45,31 +100,31 @@ const HonorSlide: React.FC<HonorSlideProps> = ({ honors, small }) => {
                 </FlexDiv>
             </FlexDiv>
 
-            <Div width="100%" height="40%" overflow="auto">
-                <FlexDiv $justifycontent="start" $margin="0 0 5px 0">
-                    <FlexDiv width="15px">
+            <CardBody width="100%" height="40%" overflow="auto">
+                <ContactRow $justifycontent="start" $margin="0 0 5px 0" wrap="nowrap">
+                    <ContactIcon width="15px">
                         <Img src="/images/envelope.svg" />
-                    </FlexDiv>
-                    <FlexDiv $margin="0 0 0 10px">
+                    </ContactIcon>
+                    <ContactText $margin="0 0 0 10px">
                         <P fontSize="sm">{honors.email}</P>
-                    </FlexDiv>
-                </FlexDiv>
+                    </ContactText>
+                </ContactRow>
 
-                <FlexDiv $justifycontent="start">
-                    <FlexDiv width="15px">
+                <ContactRow $justifycontent="start" wrap="nowrap">
+                    <ContactIcon width="15px">
                         <Img src="/images/phone.svg" />
-                    </FlexDiv>
-                    <FlexDiv $margin="0 0 0 10px">
+                    </ContactIcon>
+                    <ContactText $margin="0 0 0 10px">
                         <P fontSize="sm">{honors.phoneNumber}</P>
-                    </FlexDiv>
-                </FlexDiv>
+                    </ContactText>
+                </ContactRow>
                 <Div $margin="20px 0 0 0 " width="100%">
                     <P fontSize="sm" $whiteSpace="normal" $lineHeight={1.3}>
                         {honors.intro}
                     </P>
                 </Div>
-            </Div>
-        </Div>
+            </CardBody>
+        </Card>
     );
 };
 

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -4,7 +4,51 @@ import { paginationPropsInterface } from "../../types/TypeCommon";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
+import styled from "styled-components";
+
+const PaginationContainer = styled(FlexDiv)`
+    ${media.mobile} {
+        gap: 4px 0;
+        padding: 16px 0;
+    }
+`;
+
+const PageButton = styled(FlexDiv)`
+    width: 45px;
+    height: 45px;
+    margin: 5px;
+    padding: 5px;
+
+    ${media.mobile} {
+        width: 36px;
+        height: 36px;
+        margin: 2px;
+        padding: 4px;
+    }
+`;
+
+const NavigationButtonWrapper = styled(Div)`
+    margin: 0 8px;
+
+    ${media.mobile} {
+        margin: 0 2px;
+    }
+`;
+
+const NavigationButton = styled(FlexDiv)`
+    width: 45px;
+    height: 45px;
+    margin: 5px;
+    padding: 5px;
+
+    ${media.mobile} {
+        width: 36px;
+        height: 36px;
+        margin: 0;
+        padding: 4px;
+    }
+`;
 
 const Pagination = (props: paginationPropsInterface) => {
     const { totalPage, fetchUrl, search, size, token, paginationFetch } = props;
@@ -22,17 +66,13 @@ const Pagination = (props: paginationPropsInterface) => {
         let pageNumList = [];
         for (let i = startPage; i < startPage + 5 && i <= totalPage; i++) {
             pageNumList.push(
-                <FlexDiv
+                <PageButton
                     onClick={() => {
                         setCurrentPage(i);
                         setPageChange(true);
                     }}
                     key={`page${i}`}
                     display="flex"
-                    width="45px"
-                    height="45px"
-                    $padding="5px"
-                    $margin="5px"
                     $pointer
                     $backgroundColor={i !== currentPage ? "wh" : "bgColor"}
                     $border={`2px solid ${theme.color.bk}`}
@@ -43,7 +83,7 @@ const Pagination = (props: paginationPropsInterface) => {
                             {i}
                         </P>
                     </Div>
-                </FlexDiv>
+                </PageButton>
             );
         }
 
@@ -82,10 +122,10 @@ const Pagination = (props: paginationPropsInterface) => {
     }, [pageChange]);
 
     return (
-        <FlexDiv width="100%" $padding="20px 0">
+        <PaginationContainer width="100%" $padding="20px 0">
             {totalPage !== 1 && (
                 <>
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setAllLeftHovered(true)}
                         onMouseLeave={() => setAllLeftHovered(false)}
                         onClick={() => {
@@ -95,13 +135,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={allLeftHovered ? "bgColor" : "wh"}
                             $pointer
@@ -113,10 +148,10 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/angles-left_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
 
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setLeftHovered(true)}
                         onMouseLeave={() => setLeftHovered(false)}
                         onClick={() => {
@@ -126,13 +161,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={leftHovered ? "bgColor" : "wh"}
                             $pointer
@@ -144,8 +174,8 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/arrow-left_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
                 </>
             )}
 
@@ -153,7 +183,7 @@ const Pagination = (props: paginationPropsInterface) => {
 
             {totalPage !== 1 && (
                 <>
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setRightHovered(true)}
                         onMouseLeave={() => setRightHovered(false)}
                         onClick={() => {
@@ -163,13 +193,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             }
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={rightHovered ? "bgColor" : "wh"}
                             $pointer
@@ -181,10 +206,10 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/arrow-right_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
 
-                    <Div
+                    <NavigationButtonWrapper
                         onMouseEnter={() => setAllRightHovered(true)}
                         onMouseLeave={() => setAllRightHovered(false)}
                         onClick={() => {
@@ -192,13 +217,8 @@ const Pagination = (props: paginationPropsInterface) => {
                             setPageChange(true);
                         }}
                         $pointer
-                        $margin="0 8px"
                     >
-                        <FlexDiv
-                            width="45px"
-                            height="45px"
-                            $padding="5px"
-                            $margin="5px"
+                        <NavigationButton
                             radius={50}
                             $backgroundColor={allRightHovered ? "bgColor" : "wh"}
                             $pointer
@@ -210,11 +230,11 @@ const Pagination = (props: paginationPropsInterface) => {
                                     <Img src="/images/angles-right_purple.svg" />
                                 )}
                             </FlexDiv>
-                        </FlexDiv>
-                    </Div>
+                        </NavigationButton>
+                    </NavigationButtonWrapper>
                 </>
             )}
-        </FlexDiv>
+        </PaginationContainer>
     );
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -3,6 +3,67 @@ import P from "../styles/assets/P"
 import Img from "../styles/assets/Img";
 
 import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { media } from "../styles/theme";
+
+const NotFoundPage = styled(Div)`
+    padding: 0 16px 32px;
+
+    ${media.mobile} {
+        height: auto;
+        min-height: 100vh;
+    }
+`;
+
+const NotFoundLogo = styled(FlexDiv)`
+    ${media.tablet} {
+        width: 120px;
+        height: 120px;
+        margin-top: 80px;
+    }
+
+    ${media.mobile} {
+        width: 96px;
+        height: 96px;
+        margin-top: 56px;
+    }
+`;
+
+const ErrorCode = styled(P)`
+    ${media.tablet} {
+        font-size: 42px;
+    }
+
+    ${media.mobile} {
+        font-size: 36px;
+    }
+`;
+
+const ErrorTitle = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-align: center;
+    text-overflow: clip;
+
+    ${media.tablet} {
+        font-size: 40px;
+    }
+
+    ${media.mobile} {
+        font-size: 28px;
+    }
+`;
+
+const ErrorDescription = styled(P)`
+    white-space: normal;
+    overflow: visible;
+    text-align: center;
+    text-overflow: clip;
+
+    ${media.mobile} {
+        font-size: 16px;
+    }
+`;
 
 const NotFound = () => {
 
@@ -14,25 +75,25 @@ const NotFound = () => {
 
     return (
         <>
-            <Div width="100%" height="100vh" $backgroundColor="bgColorHo" direction="column">
+            <NotFoundPage width="100%" height="100vh" $backgroundColor="bgColorHo" direction="column">
                 <FlexDiv width="100%">
-                    <FlexDiv width="150px" height="150px" $margin="100px 0 0 0" $pointer onClick={clickButton}>
+                    <NotFoundLogo width="150px" height="150px" $margin="100px 0 0 0" $pointer onClick={clickButton}>
                         <Img src="/images/member_logo_white.png" />
-                    </FlexDiv>
+                    </NotFoundLogo>
                 </FlexDiv>
                 <FlexDiv width="100%" $margin="50px 0 0 0">
                     <Div>
-                        <P color="wh" fontSize="xxxl">404</P>
+                        <ErrorCode color="wh" fontSize="xxxl">404</ErrorCode>
                     </Div>
                 </FlexDiv>
                 <FlexDiv width="100%">
                     <Div>
-                        <P color="wh" fontSize="xxxl">페이지를 찾을 수 없습니다.</P>
+                        <ErrorTitle color="wh" fontSize="xxxl">페이지를 찾을 수 없습니다.</ErrorTitle>
                     </Div>
                 </FlexDiv>
                 <FlexDiv width="100%" $margin="50px 0 0 0">
                     <Div>
-                        <P color="wh" fontSize="xl">잘못된 페이지 경로로 접근하셨습니다.</P>
+                        <ErrorDescription color="wh" fontSize="xl">잘못된 페이지 경로로 접근하셨습니다.</ErrorDescription>
                     </Div>
                 </FlexDiv>
                 <FlexDiv width="100%" $margin="20px 0 0 0">
@@ -42,7 +103,7 @@ const NotFound = () => {
                         </P>
                     </Div>
                 </FlexDiv>
-            </Div>
+            </NotFoundPage>
         </>
     )
 }

--- a/src/pages/home/Honor.tsx
+++ b/src/pages/home/Honor.tsx
@@ -15,14 +15,93 @@ import P from "../../styles/assets/P";
 import HeaderNav from "../../components/common/HeaderNav";
 import HonorSlide from "../../components/common/HonorSlide";
 import Loading from "../../components/common/Loading";
+import { media } from "../../styles/theme";
 
 const HonorImg = styled(Img)`
     object-fit: fill;
     position: absolute;
+
+    ${media.tablet} {
+        object-fit: cover;
+    }
 `;
 const StyledSlider = styled(Slider)`
     width: 90%;
     height: 500px;
+
+    ${media.tablet} {
+        width: 100%;
+    }
+
+    ${media.mobile} {
+        height: auto;
+        max-width: calc(100vw - 32px);
+    }
+`;
+
+const HonorPage = styled(Div)`
+    ${media.tablet} {
+        height: auto;
+        min-height: 100vh;
+    }
+`;
+
+const HonorContent = styled(FlexDiv)`
+    ${media.tablet} {
+        position: relative;
+        top: auto;
+        min-height: 100vh;
+        padding: 140px 24px 56px;
+    }
+
+    ${media.mobile} {
+        padding: 112px 16px 40px;
+    }
+`;
+
+const HonorScroll = styled(Div)`
+    width: 100%;
+
+    ${media.tablet} {
+        overflow: visible;
+    }
+`;
+
+const HonorTitle = styled(H1)`
+    ${media.tablet} {
+        font-size: 40px;
+    }
+
+    ${media.mobile} {
+        font-size: 32px;
+    }
+`;
+
+const HonorDescription = styled(P)`
+    ${media.tablet} {
+        padding: 0 16px;
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
+    ${media.mobile} {
+        font-size: 16px;
+
+        br {
+            display: none;
+        }
+    }
+`;
+
+const HonorList = styled(FlexDiv)`
+    ${media.tablet} {
+        margin-top: 56px;
+    }
+
+    ${media.mobile} {
+        margin-top: 40px;
+    }
 `;
 
 const Honor = () => {
@@ -35,6 +114,15 @@ const Honor = () => {
         draggable: true,
         infinite: true,
         responsive: [
+            {
+                breakpoint: 768,
+                settings: {
+                    centerMode: false,
+                    slidesToShow: 1,
+                    slidesToScroll: 1,
+                    infinite: true,
+                },
+            },
             {
                 breakpoint: 1024,
                 settings: {
@@ -73,16 +161,15 @@ const Honor = () => {
     return (
         <>
             <HeaderNav />
-            <Div $position="relative" width="100%" height="100vh">
-                <Div width="100%" height="100vh">
+            <HonorPage $position="relative" width="100%" height="100vh">
                     <HonorImg src="/images/board-name-img.jpg" $filter=" brightness(30%)" />
-                    <FlexDiv $zIndex={2} $position="absolute" width="100%" $top="15%">
-                        <Div overflow="auto">
+                    <HonorContent $zIndex={2} $position="absolute" width="100%" $top="15%">
+                        <HonorScroll overflow="auto">
                             <FlexDiv width="100%" direction="column">
                                 <Div>
-                                    <H1 fontSize="xxxl" color="wh">
+                                    <HonorTitle fontSize="xxxl" color="wh">
                                         명예의 전당
-                                    </H1>
+                                    </HonorTitle>
                                 </Div>
                                 <Div
                                     height="3px"
@@ -92,13 +179,13 @@ const Honor = () => {
                                     $backgroundColor="wh"
                                 ></Div>
                                 <Div>
-                                    <P color="wh" $center fontSize="lg" $lineHeight={1.5} fontWeight={300}>
+                                    <HonorDescription color="wh" $center fontSize="lg" $lineHeight={1.5} fontWeight={300}>
                                         졸업생 분들 중 정보공개에 동의하신 선배님들입니다. <br />
                                         IBAS의 성장을 위해 함께해주셔서 감사합니다.
-                                    </P>
+                                    </HonorDescription>
                                 </Div>
                             </FlexDiv>
-                            <FlexDiv width="100%" $margin="80px 0 0 0">
+                            <HonorList width="100%" $margin="80px 0 0 0">
                                 <>
                                     {isLoading ? (
                                         <FlexDiv width="100%" height="50vh">
@@ -125,11 +212,10 @@ const Honor = () => {
                                         </StyledSlider>
                                     )}
                                 </>
-                            </FlexDiv>
-                        </Div>
-                    </FlexDiv>
-                </Div>
-            </Div>
+                            </HonorList>
+                        </HonorScroll>
+                    </HonorContent>
+            </HonorPage>
         </>
     );
 };

--- a/src/pages/home/Introduce.tsx
+++ b/src/pages/home/Introduce.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import useFetch from "../../hooks/useFetch";
 
@@ -24,11 +24,19 @@ import Loading from "../../components/common/Loading";
 
 const IntroduceSection = styled(Div)`
     min-height: 100vh;
+
+    ${media.tablet} {
+        height: auto;
+    }
 `;
 
 const IntroImg = styled(Img)`
     object-fit: fill;
     position: absolute;
+
+    ${media.tablet} {
+        object-fit: cover;
+    }
 `;
 
 const IntroDiv = styled(Div)`
@@ -95,6 +103,300 @@ const Li = styled.li`
         height: 10px; /* 작은 동그라미의 지름 */
         border-radius: 50%;
         background-color: #441f87; /* 작은 동그라미의 색상 */
+    }
+`;
+
+const SectionContent = styled(Div)`
+    ${media.tablet} {
+        height: auto;
+        min-height: 100vh;
+    }
+`;
+
+const HeroContent = styled(IntroDiv)`
+    ${media.tablet} {
+        top: 25%;
+        left: 0;
+        width: 100%;
+        padding: 0 32px;
+    }
+
+    ${media.mobile} {
+        top: 20%;
+        padding: 0 16px;
+    }
+`;
+
+const HeroHeading = styled(H1)`
+    ${media.tablet} {
+        font-size: 60px;
+    }
+
+    ${media.mobile} {
+        font-size: 44px;
+    }
+`;
+
+const HeroTitleBox = styled(Div)`
+    ${media.tablet} {
+        margin-bottom: 48px;
+    }
+
+    ${media.mobile} {
+        margin-bottom: 32px;
+    }
+`;
+
+const HeroCopyBox = styled(Div)`
+    ${media.tablet} {
+        width: 100%;
+        max-width: 600px;
+    }
+`;
+
+const HeroCopy = styled(P)`
+    ${media.tablet} {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
+    ${media.mobile} {
+        font-size: 16px;
+        line-height: 1.8;
+
+        br {
+            display: none;
+        }
+    }
+`;
+
+const CareerSectionContent = styled(SectionContent)`
+    ${media.tablet} {
+        min-height: 760px;
+    }
+
+    ${media.mobile} {
+        min-height: 700px;
+    }
+`;
+
+const CareerIntro = styled(Div)`
+    ${media.tablet} {
+        top: auto;
+        bottom: 12%;
+        left: 32px;
+    }
+
+    ${media.mobile} {
+        bottom: 10%;
+        left: 16px;
+
+        p {
+            font-size: 42px;
+        }
+    }
+`;
+
+const CareerExplanation = styled(Div)`
+    ${media.tablet} {
+        top: auto;
+        bottom: 10%;
+        left: 32px;
+        width: calc(100% - 64px);
+        max-height: 42%;
+        overflow-y: auto;
+
+        p {
+            white-space: pre-wrap;
+            overflow: visible;
+            text-overflow: clip;
+        }
+    }
+
+    ${media.mobile} {
+        bottom: 8%;
+        left: 16px;
+        width: calc(100% - 32px);
+        max-height: 46%;
+
+        p {
+            font-size: 16px;
+            line-height: 1.7;
+        }
+    }
+`;
+
+const CareerMenu = styled(Div)`
+    p {
+        font-size: clamp(70px, 5.56vw, 80px);
+    }
+
+    ${media.desktop} {
+        left: auto;
+        right: 5%;
+        max-width: 50%;
+
+        p {
+            font-size: 56px;
+        }
+    }
+
+    ${media.tablet} {
+        top: 12%;
+        left: auto;
+        right: 32px;
+        max-width: calc(100% - 64px);
+
+        p {
+            font-size: 44px;
+        }
+    }
+
+    ${media.mobile} {
+        top: 12%;
+        right: 16px;
+        max-width: calc(100% - 32px);
+
+        p {
+            font-size: 28px;
+        }
+    }
+`;
+
+const HistoryHeading = styled(P)`
+    ${media.tablet} {
+        font-size: 60px;
+    }
+
+    ${media.mobile} {
+        font-size: 38px;
+        letter-spacing: 3px;
+    }
+`;
+
+const HistoryHeader = styled(Div)`
+    ${media.tablet} {
+        left: 32px;
+    }
+
+    ${media.mobile} {
+        left: 16px;
+    }
+`;
+
+const HistoryScroll = styled(Div)`
+    ${media.tablet} {
+        top: 24%;
+        left: 32px;
+        width: calc(100% - 64px);
+        height: 72vh;
+    }
+
+    ${media.mobile} {
+        top: 20%;
+        left: 16px;
+        width: calc(100% - 32px);
+        height: 76vh;
+    }
+`;
+
+const TimelineRow = styled(FlexDiv)`
+    ${media.mobile} {
+        flex-direction: column;
+        flex-wrap: nowrap;
+    }
+`;
+
+const TimelineYear = styled(Div)`
+    flex-shrink: 0;
+
+    ${media.mobile} {
+        width: 100%;
+        padding: 20px 0 0;
+
+        p {
+            white-space: normal;
+        }
+    }
+`;
+
+const TimelineContent = styled(Div)`
+    ${media.mobile} {
+        width: 100%;
+
+        ul {
+            padding: 30px 16px 0 32px;
+        }
+
+        li {
+            font-size: 20px;
+        }
+
+        li::before {
+            left: -44px;
+        }
+
+        li::after {
+            left: -39px;
+        }
+
+        p {
+            white-space: normal;
+            overflow: visible;
+            text-overflow: clip;
+        }
+    }
+`;
+
+const AboutSection = styled(FlexDiv)`
+    ${media.tablet} {
+        height: auto;
+        min-height: 100vh;
+        flex-direction: column;
+        flex-wrap: nowrap;
+    }
+`;
+
+const AboutImagePanel = styled(Div)`
+    ${media.tablet} {
+        width: 100%;
+        height: 40vh;
+        min-height: 320px;
+    }
+
+    ${media.mobile} {
+        height: 35vh;
+        min-height: 260px;
+    }
+`;
+
+const AboutContent = styled(Div)`
+    ${media.tablet} {
+        width: 100%;
+        height: auto;
+        padding: 48px 32px;
+    }
+
+    ${media.mobile} {
+        padding: 40px 16px;
+
+        > div:first-child p {
+            font-size: 40px;
+        }
+
+        p {
+            white-space: normal;
+            overflow: visible;
+            text-overflow: clip;
+        }
+    }
+`;
+
+const StaffList = styled(FlexDiv)`
+    ${media.tablet} {
+        height: auto;
+        max-height: 40vh;
     }
 `;
 
@@ -231,33 +533,33 @@ const Introduce = () => {
         <>
             <HeaderNav />
             <IntroduceSection width="100%" height="100vh">
-                <Div $position="relative" width="100%" height="100vh">
+                <SectionContent $position="relative" width="100%" height="100vh">
                     <IntroImg src="/images/introduce.png" />
-                    <IntroDiv $zIndex={2} $position="absolute" $top="35%" $left="5%">
-                        <Div width="100%" $margin="0 0 80px 0">
-                            <H1 fontWeight={800} fontSize="extraBig" color="wh">
+                    <HeroContent $zIndex={2} $position="absolute" $top="35%" $left="5%">
+                        <HeroTitleBox width="100%" $margin="0 0 80px 0">
+                            <HeroHeading fontWeight={800} fontSize="extraBig" color="wh">
                                 Big Data
-                            </H1>
-                        </Div>
-                        <Div width="600px">
-                            <P color="wh" $whiteSpace="wrap" $lineHeight={2} fontSize="xl">
+                            </HeroHeading>
+                        </HeroTitleBox>
+                        <HeroCopyBox width="600px">
+                            <HeroCopy color="wh" $whiteSpace="wrap" $lineHeight={2} fontSize="xl">
                                 빅데이터란 디지털 환경에서 생성되는 데이터로
                                 <br />그 규모가 방대하고, 생성 주기도 짧고, 형태도 수치 데이터뿐 아니라 <br /> 문자와
                                 영상 데이터를 포함하는 대규모 데이터를 말합니다.
                                 <br /> 빅데이터는 과거에 비해 데이터가 폭증하였고 <br /> 데이터의 종류도 다양해져
                                 사람들의 행동은 물론이고 <br /> 위치정보와 SNS를 통해 생각과 의견까지 분석하고 예측할 수
                                 있습니다.
-                            </P>
-                        </Div>
-                    </IntroDiv>
-                </Div>
+                            </HeroCopy>
+                        </HeroCopyBox>
+                    </HeroContent>
+                </SectionContent>
             </IntroduceSection>
             <IntroduceSection width="100%" height="100vh">
-                <Div $position="relative" width="100%" height="100vh">
+                <CareerSectionContent $position="relative" width="100%" height="100vh">
                     <IntroImg src={`/images/${pageData[page].image}`} $filter="brightness(25%)" />
 
                     {page === 0 && (
-                        <Div $zIndex={2} $position="absolute" $top="60%" $left="5%">
+                        <CareerIntro $zIndex={2} $position="absolute" $top="60%" $left="5%">
                             <Div width="100%">
                                 <P color="grey" fontSize="extraBig1" fontWeight={800}>
                                     Big Data
@@ -266,19 +568,19 @@ const Introduce = () => {
                                     Career
                                 </P>
                             </Div>
-                        </Div>
+                        </CareerIntro>
                     )}
                     {page !== 0 && (
-                        <Div $zIndex={2} $position="absolute" $top="60%">
+                        <CareerExplanation $zIndex={2} $position="absolute" $top="60%">
                             <Div width="100%">
                                 <P fontWeight={600} color="wh" $whiteSpace="pre-wrap" fontSize="xl" $lineHeight={2}>
                                     {pageData[page].explain}
                                 </P>
                             </Div>
-                        </Div>
+                        </CareerExplanation>
                     )}
 
-                    <Div $zIndex={2} $position="absolute" $top="10%" $left="60%">
+                    <CareerMenu $zIndex={2} $position="absolute" $top="10%" $left="60%">
                         <Div width="100%">
                             <FlexDiv width="100%" $justifycontent="end">
                                 <Div $pointer onClick={() => careerEvent(1)}>
@@ -314,8 +616,8 @@ const Introduce = () => {
                                 </Div>
                             </FlexDiv>
                         </Div>
-                    </Div>
-                </Div>
+                    </CareerMenu>
+                </CareerSectionContent>
             </IntroduceSection>
             <IntroduceSection width="100%" height="100vh">
                 {isLoading ? (
@@ -323,13 +625,13 @@ const Introduce = () => {
                         <Loading />
                     </FlexDiv>
                 ) : (
-                    <Div $position="relative" width="100%" height="100vh">
+                    <SectionContent $position="relative" width="100%" height="100vh">
                         <IntroImg src="/images/history.jpg" />
-                        <Div $zIndex={2} $position="absolute" $top="5%" $left="5%">
+                        <HistoryHeader $zIndex={2} $position="absolute" $top="5%" $left="5%">
                             <Div width="100%">
-                                <P color="wh" $letterSpacing="5px" fontSize="extraBig" fontWeight={800}>
+                                <HistoryHeading color="wh" $letterSpacing="5px" fontSize="extraBig" fontWeight={800}>
                                     HISTORY
-                                </P>
+                                </HistoryHeading>
                             </Div>
                             {isAuthorizedOverExecutives && (
                                 <Div
@@ -344,8 +646,8 @@ const Introduce = () => {
                                     </P>
                                 </Div>
                             )}
-                        </Div>
-                        <Div
+                        </HistoryHeader>
+                        <HistoryScroll
                             width="80%"
                             height="70vh"
                             $zIndex={2}
@@ -357,13 +659,13 @@ const Introduce = () => {
                             {history &&
                                 history.length !== 0 &&
                                 Object.values(history).map((element: historyInterface) => (
-                                    <FlexDiv width="100%" $alignitems="start">
-                                        <Div $padding="50px" width="200px">
+                                    <TimelineRow width="100%" $alignitems="start">
+                                        <TimelineYear $padding="50px" width="200px">
                                             <P color="grey1" fontSize="xxl">
                                                 {element.year}
                                             </P>
-                                        </Div>
-                                        <Div width="80%">
+                                        </TimelineYear>
+                                        <TimelineContent width="80%">
                                             <Ul>
                                                 <Li>
                                                     <FlexDiv>
@@ -414,18 +716,18 @@ const Introduce = () => {
                                                     )}
                                                 </Li>
                                             </Ul>
-                                        </Div>
-                                    </FlexDiv>
+                                        </TimelineContent>
+                                    </TimelineRow>
                                 ))}
-                        </Div>
-                    </Div>
+                        </HistoryScroll>
+                    </SectionContent>
                 )}
             </IntroduceSection>
-            <FlexDiv width="100%" height="100vh" $backgroundColor="bk">
-                <Div $position="relative" width="40%" height="100vh">
+            <AboutSection width="100%" height="100vh" $backgroundColor="bk">
+                <AboutImagePanel $position="relative" width="40%" height="100vh">
                     <IntroImg src="/images/ibas_image.jpg" $filter="brightness(0.5)" />
-                </Div>
-                <Div width="60%" $padding="60px 30px" height="100vh">
+                </AboutImagePanel>
+                <AboutContent width="60%" $padding="60px 30px" height="100vh">
                     <Div>
                         <P color="wh" fontSize="extraBig1" fontWeight={800} $letterSpacing="5px">
                             IBAS
@@ -451,7 +753,7 @@ const Introduce = () => {
                             운영진
                         </P>
                     </Div>
-                    <FlexDiv width="100%" height="30vh" $justifycontent="start" $alignitems="start" overflow="auto">
+                    <StaffList width="100%" height="30vh" $justifycontent="start" $alignitems="start" overflow="auto">
                         <FlexDiv $margin="0 20px 50px 0" $justifycontent="space-between" $alignitems="start">
                             {staff &&
                                 staff.length !== 0 &&
@@ -501,9 +803,9 @@ const Introduce = () => {
                                     </Div>
                                 ))}
                         </FlexDiv>
-                    </FlexDiv>
-                </Div>
-            </FlexDiv>
+                    </StaffList>
+                </AboutContent>
+            </AboutSection>
         </>
     );
 };

--- a/src/pages/home/Main.tsx
+++ b/src/pages/home/Main.tsx
@@ -6,6 +6,7 @@ import { relogin } from "../../recoil/frontState";
 
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
+import { media } from "../../styles/theme";
 
 const MainDiv = styled(Div)`
     top: 0;
@@ -14,6 +15,56 @@ const MainDiv = styled(Div)`
     background-position: center center;
     background-size: cover;
     position: relative;
+
+    ${media.tablet} {
+        height: auto;
+        min-height: 100vh;
+    }
+`;
+
+const MainContent = styled(FlexDiv)`
+    ${media.tablet} {
+        min-height: 100vh;
+        height: auto;
+        padding: 100px 24px 40px;
+    }
+
+    ${media.mobile} {
+        padding: 88px 16px 32px;
+    }
+`;
+
+const Logo = styled(Div)`
+    ${media.tablet} {
+        width: 280px;
+        height: 280px;
+        max-width: calc(100vw - 48px);
+        max-height: calc(100vw - 48px);
+    }
+
+    ${media.mobile} {
+        width: 210px;
+        height: 210px;
+        max-width: calc(100vw - 32px);
+        max-height: calc(100vw - 32px);
+    }
+`;
+
+const MainText = styled(Div)`
+    ${media.tablet} {
+        width: min(420px, calc(100vw - 48px));
+    }
+
+    ${media.mobile} {
+        width: min(300px, calc(100vw - 32px));
+        margin-top: 32px;
+    }
+`;
+
+const MainTextImg = styled(Img)`
+    ${media.tablet} {
+        height: auto;
+    }
 `;
 
 const LogoImg = styled(Img)`
@@ -37,14 +88,14 @@ const Main = () => {
     return (
         <>
             <MainDiv width="100%" height="100vh" direction="column">
-                <FlexDiv direction="column" width="100%" height="90%">
-                    <Div width="350px" height="350px">
+                <MainContent direction="column" width="100%" height="90%">
+                    <Logo width="350px" height="350px">
                         <LogoImg src="/images/ibas-main-logo_white.png" />
-                    </Div>
-                    <Div $margin="50px 0 0 0">
-                        <Img src="/images/main-text.png" />
-                    </Div>
-                </FlexDiv>
+                    </Logo>
+                    <MainText $margin="50px 0 0 0">
+                        <MainTextImg src="/images/main-text.png" />
+                    </MainText>
+                </MainContent>
             </MainDiv>
             {/* <Bottom /> */}
         </>

--- a/src/pages/member/Login.tsx
+++ b/src/pages/member/Login.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media } from "../../styles/theme";
 
 const HrSect = styled.div`
     display: flex;
@@ -24,18 +25,93 @@ const HrSect = styled.div`
     }
 `;
 
-const KakaoButton = styled(FlexDiv)`
+const OAuthButton = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+        max-width: 250px;
+    }
+`;
+
+const KakaoButton = styled(OAuthButton)`
     background-color: #fee500;
     border: 1px solid #fee500;
 `;
 
-const NaverButton = styled(FlexDiv)`
+const NaverButton = styled(OAuthButton)`
     background-color: #03c75a;
     border: 1px solid #03c75a;
 `;
 
 const Copyright = styled(P)`
     color: rgba(0, 0, 0, 0.35);
+
+    ${media.mobile} {
+        white-space: normal;
+        overflow: visible;
+        text-align: center;
+        text-overflow: clip;
+    }
+`;
+
+const LoginPage = styled(FlexDiv)`
+    ${media.mobile} {
+        height: auto;
+        min-height: 100vh;
+        align-items: flex-start;
+    }
+`;
+
+const LoginPanel = styled(FlexDiv)`
+    ${media.desktop} {
+        width: max(27%, 380px);
+    }
+
+    ${media.tabletOnly} {
+        width: 44%;
+        padding: 0 32px;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        height: auto;
+        min-height: 100vh;
+        margin: 0;
+        padding: 48px 24px 32px;
+    }
+`;
+
+const LoginContent = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+    }
+`;
+
+const LoginLogo = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 120px;
+        margin-bottom: 24px;
+    }
+`;
+
+const LoginOptions = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+        max-width: 300px;
+    }
+`;
+
+const LoginBackground = styled(Div)`
+    ${media.desktop} {
+        width: calc(100% - max(27%, 380px));
+    }
+
+    ${media.tabletOnly} {
+        width: 56%;
+    }
+
+    ${media.mobile} {
+        display: none;
+    }
 `;
 
 const Login = () => {
@@ -51,8 +127,8 @@ const Login = () => {
 
     return (
         <>
-            <FlexDiv width="100%" height="100vh">
-                <FlexDiv
+            <LoginPage width="100%" height="100vh">
+                <LoginPanel
                     width="27%"
                     height="80%"
                     direction="column"
@@ -60,14 +136,14 @@ const Login = () => {
                     $margin="0 auto"
                     $justifycontent="space-evenly"
                 >
-                    <FlexDiv>
-                        <FlexDiv width="150px" $margin="0 0 30px 0" $pointer onClick={() => moveMain()}>
+                    <LoginContent>
+                        <LoginLogo width="150px" $margin="0 0 30px 0" $pointer onClick={() => moveMain()}>
                             <Img src="/images/ibas-main-logo_purple.png" />
-                        </FlexDiv>
+                        </LoginLogo>
 
-                        <FlexDiv width="80%">
+                        <LoginOptions width="80%">
                             <HrSect>소셜 로그인</HrSect>
-                            <FlexDiv
+                            <OAuthButton
                                 $backgroundColor="wh"
                                 width="250px"
                                 height="40px"
@@ -88,7 +164,7 @@ const Login = () => {
                                         <P fontSize="sm">Google 계정으로 로그인</P>
                                     </Div>
                                 </FlexDiv>
-                            </FlexDiv>
+                            </OAuthButton>
                             <NaverButton
                                 $backgroundColor="wh"
                                 width="250px"
@@ -133,8 +209,8 @@ const Login = () => {
                                     </Div>
                                 </FlexDiv>
                             </KakaoButton>
-                        </FlexDiv>
-                    </FlexDiv>
+                        </LoginOptions>
+                    </LoginContent>
                     <FlexDiv>
                         <Div>
                             <Copyright fontSize="xs" fontWeight={300} $lineHeight={1.3}>
@@ -147,11 +223,11 @@ const Login = () => {
                             </Copyright>
                         </Div>
                     </FlexDiv>
-                </FlexDiv>
-                <Div width="73%" height="100vh" overflow="hidden">
+                </LoginPanel>
+                <LoginBackground width="73%" height="100vh" overflow="hidden">
                     <Img src="/images/member-background.jpg" />
-                </Div>
-            </FlexDiv>
+                </LoginBackground>
+            </LoginPage>
         </>
     );
 };

--- a/src/pages/member/Rule.tsx
+++ b/src/pages/member/Rule.tsx
@@ -11,12 +11,84 @@ import { H2 } from "../../styles/assets/H";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
 import Loading from "../../components/common/Loading";
+import { media } from "../../styles/theme";
 
 const Hr = styled.hr`
     clear: both;
     margin: 2rem 0;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     width: 100%;
+`;
+
+const RulePage = styled(FlexDiv)`
+    ${media.mobile} {
+        height: auto;
+        min-height: 100vh;
+        align-items: flex-start;
+    }
+`;
+
+const RulePanel = styled(Div)`
+    ${media.tabletOnly} {
+        width: 60%;
+        padding: 0 4%;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        height: auto;
+        min-height: 100vh;
+        margin: 0;
+        padding: 32px 20px;
+    }
+`;
+
+const RuleHeader = styled(FlexDiv)`
+    ${media.mobile} {
+        flex-wrap: nowrap;
+        align-items: flex-start;
+    }
+`;
+
+const RuleLogo = styled(FlexDiv)`
+    flex-shrink: 0;
+
+    ${media.mobile} {
+        width: 34px;
+        margin-right: 12px;
+    }
+`;
+
+const RuleTitle = styled(H2)`
+    ${media.mobile} {
+        font-size: 22px;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+`;
+
+const RuleBody = styled(Div)`
+    p {
+        white-space: pre-wrap;
+        overflow: visible;
+        text-overflow: clip;
+        overflow-wrap: anywhere;
+    }
+
+    ${media.mobile} {
+        height: auto;
+        max-height: calc(100vh - 150px);
+    }
+`;
+
+const RuleBackground = styled(Div)`
+    ${media.tabletOnly} {
+        width: 40%;
+    }
+
+    ${media.mobile} {
+        display: none;
+    }
 `;
 
 const Rule = () => {
@@ -52,8 +124,8 @@ const Rule = () => {
                     <Loading />
                 </FlexDiv>
             ) : (
-                <FlexDiv width="100%" height="100vh">
-                    <Div
+                <RulePage width="100%" height="100vh">
+                    <RulePanel
                         width="56%"
                         height="80%"
                         direction="column"
@@ -61,20 +133,20 @@ const Rule = () => {
                         $margin="0 auto"
                         $justifycontent="start"
                     >
-                        <FlexDiv width="100%" $justifycontent="start">
-                            <FlexDiv width="40px" $margin="0 20px 0 0" onClick={() => movePage()} $pointer>
+                        <RuleHeader width="100%" $justifycontent="start">
+                            <RuleLogo width="40px" $margin="0 20px 0 0" onClick={() => movePage()} $pointer>
                                 <Img src="/images/ibas-main-logo_purple.png" />
-                            </FlexDiv>
+                            </RuleLogo>
                             <FlexDiv>
-                                <H2 fontSize="xxl" fontWeight={700}>
+                                <RuleTitle fontSize="xxl" fontWeight={700}>
                                     {policy?.title}
-                                </H2>
+                                </RuleTitle>
                             </FlexDiv>
 
                             <Hr />
-                        </FlexDiv>
+                        </RuleHeader>
 
-                        <Div width="100%" height="85%" overflow="auto">
+                        <RuleBody width="100%" height="85%" overflow="auto">
                             {policy && (
                                 <div>
                                     <P
@@ -96,12 +168,12 @@ const Rule = () => {
                                     <P color="wh"> 홈화면으로 돌아가기 </P>
                                 </Button>
                             </FlexDiv>
-                        </Div>
-                    </Div>
-                    <Div width="44%" height="100vh" overflow="hidden">
+                        </RuleBody>
+                    </RulePanel>
+                    <RuleBackground width="44%" height="100vh" overflow="hidden">
                         <Img src="/images/member-background.jpg" />
-                    </Div>
-                </FlexDiv>
+                    </RuleBackground>
+                </RulePage>
             )}
         </>
     );

--- a/src/pages/member/Signup.tsx
+++ b/src/pages/member/Signup.tsx
@@ -15,6 +15,7 @@ import Img from "../../styles/assets/Img";
 import { Checkbox, Label, Radio, TextInput } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
 import Dropdown from "../../components/common/Dropdown";
+import { media } from "../../styles/theme";
 
 const HrSect = styled.div`
     display: flex;
@@ -32,6 +33,111 @@ const HrSect = styled.div`
         font-size: 0px;
         line-height: 0px;
         margin: 0px 16px;
+    }
+`;
+
+const SignupPage = styled(FlexDiv)`
+    ${media.mobile} {
+        height: auto;
+        min-height: 100vh;
+        align-items: flex-start;
+    }
+`;
+
+const SignupPanel = styled(FlexDiv)`
+    ${media.desktop} {
+        width: max(33%, 420px);
+    }
+
+    ${media.tabletOnly} {
+        width: 52%;
+        padding: 0 24px;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        height: auto;
+        min-height: 100vh;
+        margin: 0;
+        padding: 32px 20px;
+    }
+`;
+
+const SignupContent = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+    }
+`;
+
+const SignupLogo = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 110px;
+        margin-bottom: 24px;
+    }
+`;
+
+const SignupFields = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+    }
+`;
+
+const StudentFields = styled(FlexDiv)`
+    ${media.mobile} {
+        flex-direction: column;
+
+        > div,
+        > input {
+            width: 100%;
+        }
+    }
+`;
+
+const MajorRow = styled(FlexDiv)`
+    min-width: 0;
+
+    p {
+        white-space: normal;
+    }
+`;
+
+const TermsRow = styled(FlexDiv)`
+    ${media.mobile} {
+        align-items: flex-start;
+    }
+`;
+
+const TermsCopy = styled(FlexDiv)`
+    min-width: 0;
+
+    ${media.mobile} {
+        width: calc(100% - 30px);
+
+        a {
+            white-space: normal;
+            overflow: visible;
+            text-overflow: clip;
+        }
+    }
+`;
+
+const NextButton = styled(Button)`
+    ${media.mobile} {
+        margin: 32px 0 0;
+    }
+`;
+
+const SignupBackground = styled(Div)`
+    ${media.desktop} {
+        width: calc(100% - max(33%, 420px));
+    }
+
+    ${media.tabletOnly} {
+        width: 48%;
+    }
+
+    ${media.mobile} {
+        display: none;
     }
 `;
 
@@ -243,8 +349,8 @@ const Signup = () => {
 
     return (
         <>
-            <FlexDiv width="100%" height="100vh">
-                <FlexDiv
+            <SignupPage width="100%" height="100vh">
+                <SignupPanel
                     width="33%"
                     height="80%"
                     direction="column"
@@ -252,10 +358,10 @@ const Signup = () => {
                     $margin="0 auto"
                     $justifycontent="space-evenly"
                 >
-                    <FlexDiv width="90%">
-                        <FlexDiv width="150px" $margin="0 0 30px 0" $pointer onClick={() => movePage()}>
+                    <SignupContent width="90%">
+                        <SignupLogo width="150px" $margin="0 0 30px 0" $pointer onClick={() => movePage()}>
                             <Img src="/images/ibas-main-logo_purple.png" />
-                        </FlexDiv>
+                        </SignupLogo>
 
                         <FlexDiv width="100%">
                             <HrSect>기본 정보</HrSect>
@@ -281,7 +387,7 @@ const Signup = () => {
                                 <Label $margin="0 0 0 5px">교수님</Label>
                             </FlexDiv>
                         </FlexDiv>
-                        <FlexDiv width="100%">
+                        <SignupFields width="100%">
                             <TextInput
                                 defaultValue={info?.name || ""}
                                 placeholder="이름"
@@ -303,7 +409,7 @@ const Signup = () => {
                                 onChange={() => autoHyphen(ref.current[3])}
                             />
                             {status === "professor" ? (
-                                <FlexDiv $justifycontent="space-between" width="90%">
+                                <StudentFields $justifycontent="space-between" width="90%">
                                     <TextInput
                                         placeholder="교수번호"
                                         defaultValue={info?.studentId || ""}
@@ -312,9 +418,9 @@ const Signup = () => {
                                         $margin="10px 0 0 0"
                                         ref={(el: never) => (ref.current[4] = el)}
                                     />
-                                </FlexDiv>
+                                </StudentFields>
                             ) : (
-                                <FlexDiv $justifycontent="space-between" width="90%">
+                                <StudentFields $justifycontent="space-between" width="90%">
                                     <Div width="30%" $margin="10px 0 0 0">
                                         <Dropdown
                                             label="학년"
@@ -332,10 +438,10 @@ const Signup = () => {
                                         $margin="10px 0 0 0"
                                         ref={(el: never) => (ref.current[6] = el)}
                                     />
-                                </FlexDiv>
+                                </StudentFields>
                             )}
 
-                            <FlexDiv
+                            <MajorRow
                                 width="90%"
                                 $margin="10px 0 0 0"
                                 $justifycontent="space-between"
@@ -352,13 +458,13 @@ const Signup = () => {
                                 <FlexDiv width="20px" $justifycontent="end">
                                     <Img src="/images/search.svg" />
                                 </FlexDiv>
-                            </FlexDiv>
+                            </MajorRow>
 
-                            <FlexDiv $justifycontent="start" width="90%" $margin="10px 0 0 0">
+                            <TermsRow $justifycontent="start" width="90%" $margin="10px 0 0 0">
                                 <Div $margin="0 10px 0 0">
                                     <Checkbox ref={(el: never) => (ref.current[7] = el)} />
                                 </Div>
-                                <FlexDiv width="80%" $justifycontent="start">
+                                <TermsCopy width="80%" $justifycontent="start">
                                     <Div>
                                         <A fontSize="xs">본인은</A>
                                     </Div>
@@ -404,9 +510,9 @@ const Signup = () => {
                                     <Div>
                                         <A fontSize="xs">에 동의합니다. </A>
                                     </Div>
-                                </FlexDiv>
+                                </TermsCopy>
 
-                                <Button
+                                <NextButton
                                     display="flex"
                                     $backgroundColor="bgColor"
                                     $margin="50px 0"
@@ -417,15 +523,15 @@ const Signup = () => {
                                     onClick={() => sendInput()}
                                 >
                                     <P color="wh">다음</P>
-                                </Button>
-                            </FlexDiv>
-                        </FlexDiv>
-                    </FlexDiv>
-                </FlexDiv>
-                <Div width="67%" height="100vh" overflow="hidden">
+                                </NextButton>
+                            </TermsRow>
+                        </SignupFields>
+                    </SignupContent>
+                </SignupPanel>
+                <SignupBackground width="67%" height="100vh" overflow="hidden">
                     <Img src="/images/member-background.jpg" />
-                </Div>
-            </FlexDiv>
+                </SignupBackground>
+            </SignupPage>
         </>
     );
 };

--- a/src/pages/member/SignupQuestion.tsx
+++ b/src/pages/member/SignupQuestion.tsx
@@ -11,6 +11,93 @@ import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import { TextArea } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
+import styled from "styled-components";
+import { media } from "../../styles/theme";
+
+const QuestionPage = styled(FlexDiv)`
+    ${media.mobile} {
+        height: auto;
+        min-height: 100vh;
+        align-items: flex-start;
+    }
+`;
+
+const QuestionPanel = styled(FlexDiv)`
+    ${media.tabletOnly} {
+        width: 60%;
+        padding: 0 32px;
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        height: auto;
+        min-height: 100vh;
+        margin: 0;
+        padding: 32px 20px;
+    }
+`;
+
+const QuestionScroll = styled(FlexDiv)`
+    ${media.mobile} {
+        width: 100%;
+        height: auto;
+        overflow: visible;
+    }
+`;
+
+const QuestionList = styled(FlexDiv)`
+    ${media.mobile} {
+        height: auto;
+        align-content: flex-start;
+
+        p {
+            white-space: normal;
+            overflow: visible;
+            text-overflow: clip;
+        }
+
+        textarea {
+            max-width: 100%;
+        }
+    }
+`;
+
+const QuestionActions = styled(FlexDiv)`
+    ${media.mobile} {
+        gap: 12px;
+        margin-top: 32px;
+    }
+`;
+
+const QuestionButton = styled(Button)`
+    min-width: 110px;
+
+    ${media.desktop} {
+        width: auto;
+        min-width: 110px;
+    }
+
+    ${media.tablet} {
+        width: auto;
+        min-width: 110px;
+    }
+
+    ${media.mobile} {
+        flex: 1;
+        min-width: 0;
+        margin: 0;
+    }
+`;
+
+const QuestionBackground = styled(Div)`
+    ${media.tabletOnly} {
+        width: 40%;
+    }
+
+    ${media.mobile} {
+        display: none;
+    }
+`;
 
 const SignupQuestion = () => {
     const navigate = useNavigate();
@@ -129,8 +216,8 @@ const SignupQuestion = () => {
 
     return (
         <>
-            <FlexDiv width="100%" height="100vh">
-                <FlexDiv
+            <QuestionPage width="100%" height="100vh">
+                <QuestionPanel
                     width="56%"
                     height="85%"
                     direction="column"
@@ -138,8 +225,8 @@ const SignupQuestion = () => {
                     $margin="0 auto"
                     $justifycontent="space-evenly"
                 >
-                    <FlexDiv width="90%" height="100%" overflow="auto">
-                        <FlexDiv width="100%" height="100%">
+                    <QuestionScroll width="90%" height="100%" overflow="auto">
+                        <QuestionList width="100%" height="100%">
                             {question &&
                                 Object.values(question).map((item: any, idx: number) => {
                                     return (
@@ -159,8 +246,8 @@ const SignupQuestion = () => {
                                         </Div>
                                     );
                                 })}
-                            <FlexDiv width="100%" $justifycontent="end">
-                                <Button
+                            <QuestionActions width="100%" $justifycontent="end">
+                                <QuestionButton
                                     display="flex"
                                     $backgroundColor="grey3"
                                     $margin="50px 30px "
@@ -171,8 +258,8 @@ const SignupQuestion = () => {
                                     onClick={() => saveInput()}
                                 >
                                     <P color="wh">임시저장</P>
-                                </Button>
-                                <Button
+                                </QuestionButton>
+                                <QuestionButton
                                     display="flex"
                                     $backgroundColor="bgColor"
                                     $margin="50px 0"
@@ -183,15 +270,15 @@ const SignupQuestion = () => {
                                     onClick={() => sendInput()}
                                 >
                                     <P color="wh">제출</P>
-                                </Button>
-                            </FlexDiv>
-                        </FlexDiv>
-                    </FlexDiv>
-                </FlexDiv>
-                <Div width="44%" height="100vh" overflow="hidden">
+                                </QuestionButton>
+                            </QuestionActions>
+                        </QuestionList>
+                    </QuestionScroll>
+                </QuestionPanel>
+                <QuestionBackground width="44%" height="100vh" overflow="hidden">
                     <Img src="/images/member-background.jpg" />
-                </Div>
-            </FlexDiv>
+                </QuestionBackground>
+            </QuestionPage>
         </>
     );
 };

--- a/src/styles/assets/Div.ts
+++ b/src/styles/assets/Div.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { DefaultTheme } from "styled-components/dist/types";
+import { media } from "../theme";
 
 interface DivStyle {
     theme: DefaultTheme;
@@ -97,12 +98,34 @@ const Container = styled(FlexDiv)`
     width: 80%;
     max-width: 80%;
     padding: 5% 0;
+
+    ${media.tablet} {
+        width: calc(100% - 48px);
+        max-width: calc(100% - 48px);
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 100%;
+        padding: 5% 16px;
+    }
 `;
 
 const DetailContainer = styled(Div)`
     width: 800px;
     max-width: 800px;
     padding: 5% 0;
+
+    ${media.tablet} {
+        width: calc(100% - 48px);
+        max-width: calc(100% - 48px);
+    }
+
+    ${media.mobile} {
+        width: 100%;
+        max-width: 100%;
+        padding: 5% 16px;
+    }
 `;
 
 const InputLabel = styled.label<DivStyle>`


### PR DESCRIPTION
## 개요

> 홈·회원 관련 화면에 태블릿·모바일 반응형 스타일을 적용합니다. 기존 데스크톱 UI와 기능은 유지하고, `#618` 범위의 화면만 대응합니다.

## 변경 사항

- HeaderNav 모바일 메뉴 헤더 레이아웃 수정
- 메인 홈 반응형 레이아웃 적용
- 소개 페이지 반응형 레이아웃 적용
- 명예의 전당 및 HonorSlide 반응형 레이아웃 적용
- 로그인 페이지 반응형 레이아웃 적용
- 회원가입 페이지 반응형 레이아웃 적용
- 가입 질문 페이지 반응형 레이아웃 적용
- 약관 페이지 반응형 레이아웃 적용
- 404 페이지 반응형 레이아웃 적용

## 변경 유형

- [x] `feat` — 새로운 기능
- [ ] `fix` — 버그 수정
- [x] `design` — UI · 스타일 변경
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `docs` — 문서
- [ ] `chore` — 빌드 설정, 패키지 변경
- [ ] `ci` — CI/CD 설정 변경
- [ ] `revert` — 이전 커밋 되돌리기

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해 주세요 -->

resolves: #618

## 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before / After 스크린샷을 첨부해 주세요 -->

| Before | After |
|--------|-------|
|        |       |

## 체크리스트

- [x] `upstream/dev` 기준으로 브랜치를 만들었다
- [ ] 빌드가 정상적으로 된다 (`npm run build`)
- [ ] ESLint 에러가 없다
- [ ] 기존 기능이 정상 작동한다
- [x] WIP 커밋을 정리했다 (`git rebase -i`)
- [ ] 불필요한 `console.log`와 주석 처리된 코드를 제거했다