### PR TITLE
[feat/#619] 게시판 및 공통 콘텐츠 UI 반응형 구현

### DIFF
--- a/src/components/board/BoardNavigate.tsx
+++ b/src/components/board/BoardNavigate.tsx
@@ -13,8 +13,46 @@ import P from "../../styles/assets/P";
 import { boardMenuInterface } from "../../types/TypeBoard";
 
 import { GetRoleAuthorization } from "../../functions/authFunctions";
+import styled from "styled-components";
+import { media } from "../../styles/theme";
 
 const HIDDEN_BOARD_MENUS = ['질문게시판', '자유게시판', '건의사항', '회장단 게시판'];
+
+const NavigateBox = styled(Div)`
+    width: 263px;
+    border: 2px solid ${theme.color.border};
+    padding: 30px 20px 10px;
+
+    ${media.tablet} {
+        width: 100%;
+    }
+
+    ${media.mobile} {
+        padding: 20px 16px 10px;
+    }
+`;
+
+const MenuRow = styled(FlexDiv)`
+    flex-wrap: nowrap;
+    align-items: flex-start;
+`;
+
+const MenuName = styled(Div)`
+    flex: 1 1 auto;
+    min-width: 0;
+    padding-right: 12px;
+`;
+
+const MenuCount = styled(Div)`
+    flex: 0 0 auto;
+`;
+
+const MenuText = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+`;
 
 const BoardNavigate = () => {
     const navigate = useNavigate();
@@ -54,7 +92,7 @@ const BoardNavigate = () => {
 
     return (
         <>
-            <Div width="263px" $border={`2px solid`} $borderColor="border" $padding="30px 20px 10px">
+            <NavigateBox>
                 <Div $borderL={`4px solid ${theme.color.bgColor}`} $padding="5px 0 5px 20px" $margin="0 0 15px 0">
                     <P fontSize="xl" fontWeight={700}>
                         게시판
@@ -66,7 +104,7 @@ const BoardNavigate = () => {
                         menu.filter((item) => !HIDDEN_BOARD_MENUS.includes(item.menuName)).map((item: any, idx: number) => {
                             return (
                                 <Div key={idx} width="100%">
-                                    <FlexDiv
+                                    <MenuRow
                                         width="100%"
                                         $padding="15px 0"
                                         $justifycontent="space-between"
@@ -74,24 +112,24 @@ const BoardNavigate = () => {
                                         onClick={() => movePageEvent(item.url)}
                                         $pointer
                                     >
-                                        <Div>
-                                            <P color="grey" fontSize="sm" fontWeight={400}>
+                                        <MenuName>
+                                            <MenuText color="grey" fontSize="sm" fontWeight={400}>
                                                 {item.menuName}
-                                            </P>
-                                        </Div>
+                                            </MenuText>
+                                        </MenuName>
                                         {item.menuName !== '건의사항' && (
-                                        <Div>
+                                        <MenuCount>
                                             <P color="grey" fontSize="sm" fontWeight={400}>
                                                 ({item.count})
                                             </P>
-                                        </Div>
+                                        </MenuCount>
                                         )}
-                                    </FlexDiv>
+                                    </MenuRow>
                                 </Div>
                             );
                         })}
                 </Div>
-            </Div>
+            </NavigateBox>
         </>
     );
 };

--- a/src/components/board/BoardSearch.tsx
+++ b/src/components/board/BoardSearch.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
-import { theme } from "../../styles/theme";
+import styled from "styled-components";
+import { media, theme } from "../../styles/theme";
 
 import { useLocation } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
@@ -18,6 +19,41 @@ import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import { SearchInput } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
+
+const SearchBox = styled(Div)`
+    width: 263px;
+    height: 147px;
+    border: 2px solid ${theme.color.border};
+    padding: 30px 20px 10px;
+
+    ${media.tablet} {
+        width: 100%;
+        height: auto;
+    }
+
+    ${media.mobile} {
+        padding: 20px 16px;
+    }
+`;
+
+const SearchRow = styled(FlexDiv)`
+    width: 100%;
+    flex-wrap: nowrap;
+`;
+
+const SearchField = styled(Div)`
+    flex: 1 1 auto;
+    min-width: 0;
+`;
+
+const ResponsiveSearchInput = styled(SearchInput)`
+    width: 100%;
+    min-width: 0;
+`;
+
+const SearchButton = styled(Button)`
+    flex: 0 0 53px;
+`;
 
 const BoardSearch = () => {
     const inputRef = useRef<HTMLInputElement>(null);
@@ -116,22 +152,22 @@ const BoardSearch = () => {
 
     return (
         <>
-            <Div width="263px" height="147px" $border={`2px solid`} $borderColor="border" $padding="30px 20px 10px">
+            <SearchBox>
                 <Div $borderL={`4px solid ${theme.color.bgColor}`} $padding="5px 0 5px 20px" $margin="0 0 15px 0">
                     <P fontSize="xl" fontWeight={700}>
                         게시글 검색
                     </P>
                 </Div>
 
-                <FlexDiv wrap="nowrap">
-                    <Div>
-                        <SearchInput
+                <SearchRow width="100%">
+                    <SearchField>
+                        <ResponsiveSearchInput
                             placeholder="검색어를 입력하세요."
                             onKeyDown={enterKeyDown}
                             onChange={handleSearchChange}
                         />
-                    </Div>
-                    <Button
+                    </SearchField>
+                    <SearchButton
                         $backgroundColor="bgColor"
                         width="53px"
                         height="40px"
@@ -143,9 +179,9 @@ const BoardSearch = () => {
                         <Div width="13px">
                             <Img src="/images/search_white.svg"></Img>
                         </Div>
-                    </Button>
-                </FlexDiv>
-            </Div>
+                    </SearchButton>
+                </SearchRow>
+            </SearchBox>
         </>
     );
 };

--- a/src/components/common/Carousel.tsx
+++ b/src/components/common/Carousel.tsx
@@ -10,10 +10,96 @@ import { carouselInterface } from "../../types/TypeCommon";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import P from "../../styles/assets/P";
+import { media, theme } from "../../styles/theme";
+
+const CarouselOverlay = styled(Div)`
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+`;
+
+const CarouselFrame = styled(Div)`
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+`;
+
+const TopBar = styled(FlexDiv)`
+    width: 100%;
+    height: 50px;
+    flex-wrap: nowrap;
+`;
+
+const SlideCount = styled(Div)`
+    min-width: 0;
+    margin: 0 30px;
+
+    ${media.mobile} {
+        margin: 0 16px;
+    }
+`;
+
+const TopActions = styled(FlexDiv)`
+    flex: 0 0 100px;
+    width: 100px;
+    flex-wrap: nowrap;
+
+    ${media.mobile} {
+        flex-basis: 88px;
+        width: 88px;
+    }
+`;
+
+const CloseButton = styled(Div)`
+    margin-right: 30px;
+
+    ${media.mobile} {
+        margin-right: 16px;
+    }
+`;
+
+const SingleImageArea = styled(FlexDiv)`
+    width: 100%;
+    height: calc(100vh - 50px);
+    height: calc(100dvh - 50px);
+    min-height: 0;
+`;
+
+const Slide = styled(Div)`
+    height: calc(100vh - 200px);
+    height: calc(100dvh - 200px);
+
+    ${media.mobile} {
+        height: calc(100vh - 150px);
+        height: calc(100dvh - 150px);
+    }
+`;
+
+const Thumbnail = styled(Div)`
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    margin-right: 10px;
+
+    ${media.mobile} {
+        width: 72px;
+        height: 72px;
+    }
+`;
 
 const StyledSlider = styled(Slider)`
     width: 100%;
     height: calc(100vh - 200px);
+    height: calc(100dvh - 200px);
+    min-width: 0;
+
+    ${media.mobile} {
+        height: calc(100vh - 150px);
+        height: calc(100dvh - 150px);
+    }
 
     .slick-prev,
     .slick-next {
@@ -22,6 +108,35 @@ const StyledSlider = styled(Slider)`
 
     .slick-list {
         overflow: hidden;
+    }
+
+    .slick-dots {
+        max-width: 100%;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-inline: contain;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: thin;
+        scrollbar-color: ${theme.color.grey2} ${theme.color.border};
+    }
+
+    .slick-dots::-webkit-scrollbar {
+        display: block;
+        height: 8px;
+    }
+
+    .slick-dots::-webkit-scrollbar-thumb {
+        background: ${theme.color.grey2};
+        border-radius: 4px;
+    }
+
+    ${media.mobile} {
+        .slick-dots li {
+            width: 72px;
+            height: 72px;
+        }
     }
 `;
 
@@ -69,9 +184,9 @@ const Carousel: React.FC<carouselInterface> = ({ images }) => {
         customPaging: (i: number) => {
             const thumb = images[i];
             return (
-                <Div display="inline-block" height="100px" width="100px" $margin="0 10px 0 0" $pointer>
+                <Thumbnail $pointer>
                     <Img $objectFit="fill" src={thumb} />
-                </Div>
+                </Thumbnail>
             );
         },
         dots: true,
@@ -106,40 +221,40 @@ const Carousel: React.FC<carouselInterface> = ({ images }) => {
     }, [images, carouselInitial]);
 
     return (
-        <Div width="100%" height="100vh" $position="absolute" $top="0" $left="0" $zIndex={9999} $backgroundColor="wh">
-            <Div $position="relative" width="100%">
-                <FlexDiv width="100%" $backgroundColor="bgColor" height="50px" $justifycontent="space-between">
-                    <Div $margin="0 30px">
+        <CarouselOverlay $zIndex={9999} $backgroundColor="wh">
+            <CarouselFrame $position="relative">
+                <TopBar $backgroundColor="bgColor" $justifycontent="space-between">
+                    <SlideCount>
                         <P color="wh">
                             {currentSlide + 1} / {images.length}
                         </P>
-                    </Div>
-                    <FlexDiv width="100px" $justifycontent="space-around">
+                    </SlideCount>
+                    <TopActions $justifycontent="space-around">
                         <Div $pointer width="20px" height="20px" onClick={handleDownload}>
                             <Img src="/images/download_white.svg" />
                         </Div>
-                        <Div $pointer $margin="0 30px 0 0" onClick={moveBack}>
+                        <CloseButton $pointer onClick={moveBack}>
                             <P color="wh" fontWeight={800}>
                                 X
                             </P>
-                        </Div>
-                    </FlexDiv>
-                </FlexDiv>
+                        </CloseButton>
+                    </TopActions>
+                </TopBar>
                 {images.length === 1 ? (
-                    <FlexDiv width="100%" height="calc(100vh - 50px)">
+                    <SingleImageArea>
                         <Img $objectFit="contain" src={images[0]} />
-                    </FlexDiv>
+                    </SingleImageArea>
                 ) : (
                     <StyledSlider {...settings} ref={sliderRef}>
                         {images.map((image, index) => (
-                            <Div key={index} height="calc(100vh - 200px)">
+                            <Slide key={index}>
                                 <Img $objectFit="contain" src={image} />
-                            </Div>
+                            </Slide>
                         ))}
                     </StyledSlider>
                 )}
-            </Div>
-        </Div>
+            </CarouselFrame>
+        </CarouselOverlay>
     );
 };
 

--- a/src/components/common/CommentInput.tsx
+++ b/src/components/common/CommentInput.tsx
@@ -9,16 +9,39 @@ import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import { TextArea } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 const CommentRelativeDiv = styled(Div)`
     position: relative;
+    min-width: 0;
 `;
 
 const CommentAbsoluteDiv = styled(Div)`
     position: absolute;
     right: 20px;
     top: 20px;
+
+    ${media.mobile} {
+        right: 14px;
+        top: 14px;
+        margin: 0;
+    }
+`;
+
+const CommentTextArea = styled(TextArea)`
+    max-width: 100%;
+    padding-right: 50px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+
+    ${media.mobile} {
+        padding: 16px 42px 16px 16px;
+        border-radius: 20px;
+    }
+`;
+
+const CommentSubmitButton = styled(Button)`
+    max-width: 100%;
 `;
 
 const CommentInput = (props: commentPropsInterface) => {
@@ -57,7 +80,7 @@ const CommentInput = (props: commentPropsInterface) => {
         <>
             <Div width="100%" $padding="30px 0 0 0" $borderT={`1px solid ${theme.color.border}`}>
                 <CommentRelativeDiv width="100%">
-                    <TextArea
+                    <CommentTextArea
                         width="100%"
                         $padding="20px"
                         $borderRadius={30}
@@ -66,7 +89,7 @@ const CommentInput = (props: commentPropsInterface) => {
                         placeholder="댓글을 남겨보세요!"
                         value={commentInput}
                         onChange={(e: any) => setCommentInput(() => e.target.value)}
-                    ></TextArea>
+                    ></CommentTextArea>
 
                     <CommentAbsoluteDiv width="14px" $margin="0 10px 0 0">
                         <Img src="/images/pencil_purple.svg" />
@@ -74,7 +97,7 @@ const CommentInput = (props: commentPropsInterface) => {
                 </CommentRelativeDiv>
             </Div>
             <FlexDiv $justifycontent="end" width="100%" $margin="30px 0 0 0">
-                <Button
+                <CommentSubmitButton
                     $backgroundColor="bgColor"
                     $borderRadius={50}
                     $padding="15px 40px"
@@ -84,7 +107,7 @@ const CommentInput = (props: commentPropsInterface) => {
                     <P color="wh" fontSize="sm" $letterSpacing="1px">
                         댓글등록
                     </P>
-                </Button>
+                </CommentSubmitButton>
             </FlexDiv>
         </>
     );

--- a/src/components/common/CommentList.tsx
+++ b/src/components/common/CommentList.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
+import styled from "styled-components";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import { jwtDecode } from "jwt-decode";
 import { GetRoleAuthorization } from "../../functions/authFunctions";
@@ -19,6 +20,131 @@ import { TextArea } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
 import CommentInput from "./CommentInput";
 import Loading from "./Loading";
+
+const CommentCard = styled(Div)`
+    min-width: 0;
+
+    ${media.mobile} {
+        padding: 14px;
+    }
+`;
+
+const CommentHeader = styled(FlexDiv)`
+    min-width: 0;
+`;
+
+const CommentHeaderLayout = styled(FlexDiv)`
+    min-width: 0;
+    flex-wrap: nowrap;
+
+    ${media.mobile} {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 12px;
+    }
+`;
+
+const AuthorBlock = styled(FlexDiv)`
+    min-width: 0;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+`;
+
+const AuthorMeta = styled(FlexDiv)`
+    min-width: 0;
+
+    ${media.mobile} {
+        height: auto;
+        justify-content: flex-start;
+    }
+`;
+
+const AuthorInfo = styled(FlexDiv)`
+    min-width: 0;
+    justify-content: flex-start;
+    row-gap: 4px;
+`;
+
+const WriterDetails = styled(FlexDiv)`
+    min-width: 0;
+    justify-content: flex-start;
+    row-gap: 4px;
+`;
+
+const WrapText = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+`;
+
+const ActionContainer = styled(Div)`
+    min-width: 0;
+
+    ${media.mobile} {
+        width: 100%;
+    }
+`;
+
+const ActionBar = styled(FlexDiv)`
+    gap: 8px 0;
+
+    ${media.mobile} {
+        justify-content: flex-start;
+    }
+`;
+
+const ParentPreview = styled(FlexDiv)`
+    min-width: 0;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+`;
+
+const ParentAuthor = styled(Div)`
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 40%;
+`;
+
+const ParentComment = styled(Div)`
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+const EditingTextArea = styled(TextArea)`
+    max-width: 100%;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+
+    ${media.mobile} {
+        padding: 16px;
+        border-radius: 20px;
+    }
+`;
+
+const CommentContent = styled(P).attrs({ $whiteSpace: "pre-wrap" })`
+    white-space: pre-wrap;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+`;
+
+const Replies = styled(Div)<{ $depth: number }>`
+    width: 100%;
+    min-width: 0;
+    padding-left: ${(props) => (props.$depth <= 4 ? "20px" : "0")};
+
+    ${media.tablet} {
+        padding-left: ${(props) => (props.$depth <= 3 ? "12px" : "0")};
+    }
+
+    ${media.mobile} {
+        padding-left: ${(props) => (props.$depth <= 2 ? "8px" : "0")};
+    }
+`;
 
 const CommentList = (props: commentPropsInterface) => {
     const { boardId, menuId, token } = props;
@@ -174,11 +300,11 @@ const CommentList = (props: commentPropsInterface) => {
                 $borderT={!depth ? `1px solid ${theme.color.border}` : "none"}
                 key={`${comment.id}_${depth}_${comment.writer.id}`}
             >
-                <Div width="100%" $border="1px solid" $margin="15px 0" $padding="20px" $borderColor="grey1">
+                <CommentCard width="100%" $border="1px solid" $margin="15px 0" $padding="20px" $borderColor="grey1">
                     <Div width="100%">
-                        <FlexDiv width="100%" $padding="0 0 20px 0">
-                            <FlexDiv width="100%" $justifycontent="space-between">
-                                <FlexDiv>
+                        <CommentHeader width="100%" $padding="0 0 20px 0">
+                            <CommentHeaderLayout width="100%" $justifycontent="space-between">
+                                <AuthorBlock>
                                     <FlexDiv
                                         width="30px"
                                         height="30px"
@@ -188,38 +314,38 @@ const CommentList = (props: commentPropsInterface) => {
                                     >
                                         <Img src={comment?.writer.pictureUrl} $objectFit="cover" />
                                     </FlexDiv>
-                                    <FlexDiv height="30px">
-                                        <FlexDiv>
+                                    <AuthorMeta height="30px">
+                                        <AuthorInfo>
                                             <Div>
-                                                <P fontSize="sm" fontWeight={700}>
+                                                <WrapText fontSize="sm" fontWeight={700}>
                                                     {comment?.writer.name}
-                                                </P>
+                                                </WrapText>
                                             </Div>
                                             <Div>
-                                                <FlexDiv>
+                                                <WriterDetails>
                                                     <Div>
-                                                        <P fontSize="xs" color="grey4">
+                                                        <WrapText fontSize="xs" color="grey4">
                                                             ({comment?.writer.major}) |
-                                                        </P>
+                                                        </WrapText>
                                                     </Div>
                                                     <FlexDiv width="13px" height="13px" $margin="0 5px">
                                                         <Img src="/images/clock_grey.svg"></Img>
                                                     </FlexDiv>
                                                     <Div>
-                                                        <P fontSize="xs" color="grey4">
+                                                        <WrapText fontSize="xs" color="grey4">
                                                             {formatDateMinute({
                                                                 date: String(comment?.dateUpdated) || "",
                                                             })}
-                                                        </P>
+                                                        </WrapText>
                                                     </Div>
-                                                </FlexDiv>
+                                                </WriterDetails>
                                             </Div>
-                                        </FlexDiv>
-                                    </FlexDiv>
-                                </FlexDiv>
-                                <Div>
+                                        </AuthorInfo>
+                                    </AuthorMeta>
+                                </AuthorBlock>
+                                <ActionContainer>
                                     {isAuthorizedOverDeactivate && !comment.isDeleted && (
-                                        <FlexDiv width="100%" $justifycontent="space-between">
+                                        <ActionBar width="100%" $justifycontent="space-between">
                                             <FlexDiv $pointer onClick={() => handleCommentButtonClick(comment?.id)}>
                                                 <FlexDiv width="13px" height="13px" $margin="0 5px 0 0">
                                                     <Img src="/images/comment_purple.svg"></Img>
@@ -283,25 +409,25 @@ const CommentList = (props: commentPropsInterface) => {
                                                     </FlexDiv>
                                                 )}
                                             </FlexDiv>
-                                        </FlexDiv>
+                                        </ActionBar>
                                     )}
-                                </Div>
-                            </FlexDiv>
-                        </FlexDiv>
+                                </ActionContainer>
+                            </CommentHeaderLayout>
+                        </CommentHeader>
                     </Div>
                     {depth !== 0 && (
-                        <FlexDiv width="100%" $justifycontent="start">
-                            <Div $margin="0 10px 0 0">
-                                <P fontSize="sm" fontWeight={300} $lineHeight={1.5} color="blue">
+                        <ParentPreview width="100%" $justifycontent="start">
+                            <ParentAuthor $margin="0 10px 0 0">
+                                <WrapText fontSize="sm" fontWeight={300} $lineHeight={1.5} color="blue">
                                     @{comment?.parentAuthor}
-                                </P>
-                            </Div>
-                            <Div width="90%" overflow="hidden" $whiteSpace="nowrap">
+                                </WrapText>
+                            </ParentAuthor>
+                            <ParentComment>
                                 <P fontSize="sm" fontWeight={300} $lineHeight={1.5} color="grey2">
                                     {comment?.parentComment}
                                 </P>
-                            </Div>
-                        </FlexDiv>
+                            </ParentComment>
+                        </ParentPreview>
                     )}
 
                     {isLoading && editingCommentId === comment.id ? (
@@ -310,7 +436,7 @@ const CommentList = (props: commentPropsInterface) => {
                         </FlexDiv>
                     ) : isEditing(comment.id) ? (
                         <Div $margin="15px 0" width="100%">
-                            <TextArea
+                            <EditingTextArea
                                 width="100%"
                                 $padding="20px"
                                 $borderRadius={30}
@@ -324,9 +450,9 @@ const CommentList = (props: commentPropsInterface) => {
                         </Div>
                     ) : (
                         <Div>
-                            <P $whiteSpace="wrap" fontSize="sm" fontWeight={300} $lineHeight={1.5}>
+                            <CommentContent fontSize="sm" fontWeight={300} $lineHeight={1.5}>
                                 {comment?.content}
-                            </P>
+                            </CommentContent>
                         </Div>
                     )}
 
@@ -335,12 +461,12 @@ const CommentList = (props: commentPropsInterface) => {
                             <CommentInput boardId={props.boardId} menuId={props.menuId} parentId={comment?.id} />
                         </Div>
                     )}
-                </Div>
+                </CommentCard>
                 {/* 대댓글 렌더링 */}
                 {comment.childrenComment && (
-                    <Div width="100%" $padding="0 0 0 20px">
+                    <Replies $depth={depth + 1}>
                         {renderCommentsRecursively(comment.childrenComment, depth + 1)}
-                    </Div>
+                    </Replies>
                 )}
             </Div>
         ));

--- a/src/components/common/DragNDrop.tsx
+++ b/src/components/common/DragNDrop.tsx
@@ -12,7 +12,7 @@ import { Div, FlexDiv, InputLabel } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import { Input } from "../../styles/assets/Input";
 import P from "../../styles/assets/P";
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 import Loading from "./Loading";
 
 interface DragNDropProps {
@@ -27,10 +27,19 @@ const ScrollFlexDiv = styled(FlexDiv)`
     align-items: ${(props) => props.$alignitems || "center"};
     justify-content: ${(props) => props.$justifycontent || "center"};
     flex-direction: ${(props) => props.direction || "row"};
-    flex-wrap: ${(props) => props.wrap || "wrap"};
+    flex-wrap: nowrap;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
 
     &::-webkit-scrollbar {
         display: block;
+        height: 8px;
     }
 
     &::-webkit-scrollbar-thumb {
@@ -42,6 +51,41 @@ const ScrollFlexDiv = styled(FlexDiv)`
     &::-webkit-scrollbar-thumb:hover {
         background-color: ${(props) => props.theme.color.grey}; /* 스크롤바 썸의 호버 색상을 지정하세요 */
     }
+`;
+
+const DropZone = styled(Div)`
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    padding: 20px 20px 3px;
+
+    ${media.mobile} {
+        padding: 14px 12px 3px;
+    }
+`;
+
+const UploadPrompt = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+    text-align: center;
+    line-height: 1.5;
+`;
+
+const PreviewCard = styled(Div)`
+    flex: 0 0 auto;
+    max-width: 100%;
+    overflow: hidden;
+`;
+
+const PreviewName = styled(P).attrs({ $whiteSpace: "normal" })`
+    max-width: 76px;
+    max-height: 76px;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
 `;
 
 const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => {
@@ -320,12 +364,10 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                 accept={onlyImg ? "image/*" : undefined}
                 draggable="true"
             />
-            <Div
+            <DropZone
                 id="dropZone"
                 $border="2px dashed"
                 $borderColor="border"
-                width="100%"
-                $padding="20px 20px 3px 20px"
                 onDragOver={(e: React.DragEvent<HTMLDivElement>) => e.preventDefault()}
                 onDrop={handleDrop}
             >
@@ -335,7 +377,7 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                             <Img src="/images/upload_grey.svg" />
                         </FlexDiv>
                         <FlexDiv $margin="0 0 20px 0">
-                            <P>클릭하거나 드래그하여 파일을 업로드하세요</P>
+                            <UploadPrompt>클릭하거나 드래그하여 파일을 업로드하세요</UploadPrompt>
                         </FlexDiv>
                     </FlexDiv>
                 </InputLabel>
@@ -344,9 +386,9 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                         <Loading />
                     </FlexDiv>
                 ) : (
-                    <ScrollFlexDiv width="100%" overflow="auto" $justifycontent="start" wrap="no-wrap">
+                    <ScrollFlexDiv $justifycontent="start">
                         {previews.map((preview, index) => (
-                            <Div
+                            <PreviewCard
                                 key={index}
                                 $position="relative"
                                 display="inline-block"
@@ -359,6 +401,7 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                                 onMouseLeave={() => {
                                     setHover(null);
                                 }}
+                                title={preview.name}
                             >
                                 <FlexDiv width="96px" height="96px" $position="relative">
                                     <FlexDiv width={preview.width} height={preview.height}>
@@ -379,9 +422,9 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                                             }}
                                         >
                                             <Div>
-                                                <P fontSize="xs" $whiteSpace="normal" fontWeight={700}>
+                                                <PreviewName fontSize="xs" fontWeight={700}>
                                                     {preview.name}
-                                                </P>
+                                                </PreviewName>
                                             </Div>
                                         </FlexDiv>
                                     )}
@@ -400,11 +443,11 @@ const DragNDrop: React.FC<DragNDropProps> = ({ single, onlyImg, fileFetch }) => 
                                         <Img src="/images/x_white.svg" alt="Delete Preview" />
                                     </Div>
                                 </FlexDiv>
-                            </Div>
+                            </PreviewCard>
                         ))}
                     </ScrollFlexDiv>
                 )}
-            </Div>
+            </DropZone>
         </>
     );
 };

--- a/src/components/common/NavigateTable.tsx
+++ b/src/components/common/NavigateTable.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 
 import { theme } from "../../styles/theme";
 
@@ -15,19 +16,74 @@ type NavigateTableProp = {
     pinnedContents?: any[];
 };
 
+const TableScroll = styled.div`
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: ${theme.color.grey2} ${theme.color.border};
+
+    &::-webkit-scrollbar {
+        display: block;
+        height: 8px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: ${theme.color.border};
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: ${theme.color.grey2};
+        border-radius: 4px;
+    }
+`;
+
+const TableContent = styled.div<{ $minWidth: number }>`
+    width: max(100%, ${(props) => props.$minWidth}px);
+`;
+
+const TableRow = styled(FlexDiv)`
+    min-width: 100%;
+    flex-wrap: nowrap;
+`;
+
+const TableCell = styled(FlexDiv)`
+    flex: 0 0 auto;
+    min-width: 0;
+
+    > div {
+        width: 100%;
+        min-width: 0;
+    }
+
+    a,
+    p {
+        display: block;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+`;
+
 // navigate url, headerInfo, widthList, contents를 props로 받아올 것
 // contents 에서 첫 요소는 idx + 1을, 두번째 요소는 데이터 id 값을, 3번째 요소는 title을 받아와야 함
 const NavigateTable = (props: NavigateTableProp) => {
     const { contents, url, width, header, pinnedContents } = props;
     const navigate = useNavigate();
+    const tableMinWidth = width.reduce((sum, item) => sum + item, 0) + 46;
 
     const movePage = (url: string, idx: number) => {
         navigate(`${url}/${idx}`);
     };
 
     return (
-        <Div width="100%">
-            <FlexDiv
+        <TableScroll role="region" aria-label="게시글 목록" tabIndex={0}>
+            <TableContent $minWidth={tableMinWidth}>
+            <TableRow
                 width="100%"
                 height="45px"
                 $borderT={`1px solid ${theme.color.grey1}`}
@@ -37,7 +93,7 @@ const NavigateTable = (props: NavigateTableProp) => {
             >
                 {header &&
                     header.map((item: string, idx: number) => (
-                        <FlexDiv
+                        <TableCell
                             key={`headerInfo${idx}`}
                             width={width && `${width[idx]}px`}
                             // $justifycontent={idx === 2 ? "start" : "center"}
@@ -48,12 +104,12 @@ const NavigateTable = (props: NavigateTableProp) => {
                                     {item}
                                 </P>
                             </Div>
-                        </FlexDiv>
+                        </TableCell>
                     ))}
-            </FlexDiv>
+            </TableRow>
             {pinnedContents &&
                 pinnedContents.map((element: object, idx: number) => (
-                    <FlexDiv
+                    <TableRow
                         key={`contentItem${idx}`}
                         width="100%"
                         height="45px"
@@ -61,13 +117,13 @@ const NavigateTable = (props: NavigateTableProp) => {
                         $padding="0 18px"
                         style={{ backgroundColor: "#fff7e4" }}
                     >
-                        <FlexDiv width={width && `${width[0]}px`} $margin="0 10px 0 0">
+                        <TableCell width={width && `${width[0]}px`} $margin="0 10px 0 0">
                             <Div width="17px" height="17px">
                                 <Img src="/images/tack_grey.svg" />
                             </Div>
-                        </FlexDiv>
+                        </TableCell>
                         {Object.entries(element).map(([key, value], idx) => (
-                            <FlexDiv
+                            <TableCell
                                 key={`itemValue${idx}`}
                                 width={width && `${width[idx + 1]}px`}
                                 $justifycontent={idx === 1 ? "start" : "center"}
@@ -85,13 +141,13 @@ const NavigateTable = (props: NavigateTableProp) => {
                                         </A>
                                     )}
                                 </Div>
-                            </FlexDiv>
+                            </TableCell>
                         ))}
-                    </FlexDiv>
+                    </TableRow>
                 ))}
             {contents.length !== 0 ? (
                 contents.map((element: object, idx: number) => (
-                    <FlexDiv
+                    <TableRow
                         key={`contentItem${idx}`}
                         width="100%"
                         height="45px"
@@ -100,7 +156,7 @@ const NavigateTable = (props: NavigateTableProp) => {
                         $backgroundColor="wh"
                     >
                         {Object.entries(element).map(([key, value], idx) => (
-                            <FlexDiv
+                            <TableCell
                                 key={`itemValue${idx}`}
                                 width={width && `${width[idx]}px`}
                                 $justifycontent={idx === 2 ? "start" : "center"}
@@ -119,12 +175,12 @@ const NavigateTable = (props: NavigateTableProp) => {
                                         </A>
                                     )}
                                 </Div>
-                            </FlexDiv>
+                            </TableCell>
                         ))}
-                    </FlexDiv>
+                    </TableRow>
                 ))
             ) : (
-                <FlexDiv
+                <TableRow
                     width="100%"
                     height="45px"
                     $borderT={`1px solid ${theme.color.grey1}`}
@@ -134,9 +190,10 @@ const NavigateTable = (props: NavigateTableProp) => {
                     <Div>
                         <P>게시글이 존재하지 않습니다</P>
                     </Div>
-                </FlexDiv>
+                </TableRow>
             )}
-        </Div>
+            </TableContent>
+        </TableScroll>
     );
 };
 

--- a/src/components/common/TextEditor.tsx
+++ b/src/components/common/TextEditor.tsx
@@ -5,7 +5,64 @@ import { Editor } from "@toast-ui/react-editor";
 import colorSyntax from "@toast-ui/editor-plugin-color-syntax";
 import "@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css";
 import { forwardRef } from "react";
+import styled from "styled-components";
 import "tui-color-picker/dist/tui-color-picker.css";
+import { media, theme } from "../../styles/theme";
+
+const EditorWrapper = styled.div`
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: ${theme.color.grey2} ${theme.color.border};
+
+    &::-webkit-scrollbar,
+    .toastui-editor-defaultUI-toolbar::-webkit-scrollbar {
+        display: block;
+        height: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb,
+    .toastui-editor-defaultUI-toolbar::-webkit-scrollbar-thumb {
+        background: ${theme.color.grey2};
+        border-radius: 4px;
+    }
+
+    .toastui-editor-defaultUI {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .toastui-editor-defaultUI-toolbar {
+        max-width: 100%;
+        overflow-x: auto;
+        overflow-y: hidden;
+        white-space: nowrap;
+        scrollbar-width: thin;
+    }
+
+    ${media.mobile} {
+        .toastui-editor-dropdown-toolbar {
+            width: min(280px, calc(100vw - 64px));
+            max-width: calc(100vw - 64px);
+            height: auto;
+            max-height: 180px;
+            flex-wrap: wrap;
+            overflow-x: hidden;
+            overflow-y: auto;
+        }
+    }
+
+    .toastui-editor-main,
+    .toastui-editor-md-container,
+    .toastui-editor-ww-container {
+        min-width: 0;
+        max-width: 100%;
+    }
+`;
 
 const colorSyntaxOptions = {
     preset: [
@@ -30,23 +87,25 @@ const colorSyntaxOptions = {
 
 const TextEditor = forwardRef(({ initialContent }: { initialContent?: string }, ref) => {
     return (
-        <Editor
-            ref={ref as React.MutableRefObject<Editor>}
-            height="500px"
-            previewStyle="vertical"
-            initialEditType="markdown"
-            initialValue={initialContent}
-            toolbarItems={[
-                // 툴바 옵션 설정
-                ["heading", "bold", "italic", "strike"],
-                ["hr", "quote"],
-                ["ul", "ol", "task", "indent", "outdent"],
-                ["table", "image", "link"],
-                ["code", "codeblock"],
-            ]}
-            usageStatistics={false} // 통계 수집 거부
-            plugins={[[colorSyntax, colorSyntaxOptions]]}
-        />
+        <EditorWrapper>
+            <Editor
+                ref={ref as React.MutableRefObject<Editor>}
+                height="500px"
+                previewStyle="vertical"
+                initialEditType="markdown"
+                initialValue={initialContent}
+                toolbarItems={[
+                    // 툴바 옵션 설정
+                    ["heading", "bold", "italic", "strike"],
+                    ["hr", "quote"],
+                    ["ul", "ol", "task", "indent", "outdent"],
+                    ["table", "image", "link"],
+                    ["code", "codeblock"],
+                ]}
+                usageStatistics={false} // 통계 수집 거부
+                plugins={[[colorSyntax, colorSyntaxOptions]]}
+            />
+        </EditorWrapper>
     );
 });
 

--- a/src/components/common/TextViewer.tsx
+++ b/src/components/common/TextViewer.tsx
@@ -1,13 +1,81 @@
 import "@toast-ui/editor/dist/toastui-editor-viewer.css";
 import { Viewer } from "@toast-ui/react-editor";
 import React from "react";
+import styled from "styled-components";
+import { theme } from "../../styles/theme";
 
 interface Props {
     contents: string;
 }
 
+const ViewerWrapper = styled.div`
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+
+    .toastui-editor-contents {
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+
+    .toastui-editor-contents img {
+        max-width: 100%;
+        height: auto;
+    }
+
+    .toastui-editor-contents table,
+    .toastui-editor-contents pre {
+        display: block;
+        max-width: 100%;
+        overflow-x: auto;
+        overscroll-behavior-inline: contain;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: thin;
+        scrollbar-color: ${theme.color.grey2} ${theme.color.border};
+    }
+
+    .toastui-editor-contents table::-webkit-scrollbar,
+    .toastui-editor-contents pre::-webkit-scrollbar {
+        display: block;
+        height: 8px;
+    }
+
+    .toastui-editor-contents table::-webkit-scrollbar-thumb,
+    .toastui-editor-contents pre::-webkit-scrollbar-thumb {
+        background: ${theme.color.grey2};
+        border-radius: 4px;
+    }
+
+    .toastui-editor-contents pre,
+    .toastui-editor-contents pre code {
+        white-space: pre;
+        word-break: normal;
+        overflow-wrap: normal;
+    }
+
+    .toastui-editor-contents p,
+    .toastui-editor-contents a,
+    .toastui-editor-contents blockquote,
+    .toastui-editor-contents li,
+    .toastui-editor-contents h1,
+    .toastui-editor-contents h2,
+    .toastui-editor-contents h3,
+    .toastui-editor-contents h4,
+    .toastui-editor-contents h5,
+    .toastui-editor-contents h6 {
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+`;
+
 const TextViewer: React.FC<Props> = ({ contents }) => {
-    return <Viewer initialValue={contents || ""} />;
+    return (
+        <ViewerWrapper>
+            <Viewer initialValue={contents || ""} />
+        </ViewerWrapper>
+    );
 };
 
 export default TextViewer;

--- a/src/pages/board/BoardCreate.tsx
+++ b/src/pages/board/BoardCreate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import styled from "styled-components";
 
 import useFetch from "../../hooks/useFetch";
 
@@ -9,7 +10,7 @@ import { menuId, refetch, selectedFile } from "../../recoil/frontState";
 
 import { boardDetailInterface } from "../../types/TypeBoard";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import DragNDrop from "../../components/common/DragNDrop";
 import Dropdown from "../../components/common/Dropdown";
@@ -25,6 +26,88 @@ import TextEditor from "../../components/common/TextEditor";
 import { tokenInterface } from "../../types/TypeCommon";
 
 import { jwtDecode } from "jwt-decode";
+
+const PolicyNotice = styled(FlexDiv)`
+    padding: 15px 20px;
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    border: 1px solid ${theme.color.bgColor};
+    border-radius: 5px;
+
+    ${media.mobile} {
+        align-items: flex-start;
+        padding: 14px 16px;
+    }
+`;
+
+const PolicyIcon = styled(Div)`
+    flex: 0 0 25px;
+`;
+
+const PolicyText = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+    line-height: 1.5;
+`;
+
+const FormCard = styled(Div)`
+    min-width: 0;
+`;
+
+const FormHeader = styled(FlexDiv)`
+    width: 100%;
+    padding: 20px;
+    justify-content: space-between;
+    border-bottom: 1px solid ${theme.color.border};
+
+    ${media.mobile} {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 16px;
+        padding: 16px;
+    }
+`;
+
+const FormSection = styled(Div)`
+    width: 100%;
+    min-width: 0;
+    padding: 20px;
+
+    ${media.mobile} {
+        padding: 12px;
+    }
+`;
+
+const ResponsiveTextInput = styled(TextInput)`
+    max-width: 100%;
+
+    ${media.mobile} {
+        height: 52px;
+        font-size: ${theme.fontSize.lg};
+    }
+`;
+
+const ResponsiveDateInput = styled(DateInput)`
+    max-width: 100%;
+    box-sizing: border-box;
+
+    ${media.mobile} {
+        height: 52px;
+        font-size: ${theme.fontSize.lg};
+    }
+`;
+
+const SubmitButton = styled(Button)`
+    width: 400px;
+    max-width: 100%;
+
+    ${media.mobile} {
+        width: 100%;
+    }
+`;
 
 const BoardCreate = () => {
     const location = useLocation();
@@ -183,31 +266,19 @@ const BoardCreate = () => {
             ) : (
                 <Container $alignitems="start">
                     <Div width="100%" $margin="0 0 30px 0">
-                        <FlexDiv
-                            $padding="15px 20px"
-                            width="100%"
-                            $justifycontent="start"
-                            radius={5}
-                            $border="1px solid"
-                            $borderColor="bgColor"
-                        >
-                            <Div width="25px" height="25px" $margin="0 10px 0 0">
+                        <PolicyNotice>
+                            <PolicyIcon width="25px" height="25px" $margin="0 10px 0 0">
                                 <Img src="/images/triangle-warning_purple.svg"></Img>
-                            </Div>
-                            <Div>
-                                <P color="bgColor" fontSize="sm" fontWeight={700}>
+                            </PolicyIcon>
+                            <Div width="100%">
+                                <PolicyText color="bgColor" fontSize="sm" fontWeight={700}>
                                     웹사이트 운영 정책을 위반하는 게시글은 예고 없이 삭제 될 수 있습니다.
-                                </P>
+                                </PolicyText>
                             </Div>
-                        </FlexDiv>
+                        </PolicyNotice>
 
-                        <Div width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
-                            <FlexDiv
-                                width=" 100%"
-                                $padding="20px"
-                                $justifycontent="space-between"
-                                $borderB={`1px solid ${theme.color.border}`}
-                            >
+                        <FormCard width="100%" $border="1px solid" $borderColor="border" $margin="20px 0" radius={6}>
+                            <FormHeader>
                                 <Div>
                                     <P fontWeight={600}>게시글 작성</P>
                                 </Div>
@@ -221,10 +292,10 @@ const BoardCreate = () => {
                                         />
                                     </Div>
                                 )}
-                            </FlexDiv>
-                            <Div width="100%" $padding="20px">
+                            </FormHeader>
+                            <FormSection>
                                 <Div width="100%">
-                                    <TextInput
+                                    <ResponsiveTextInput
                                         width="100%"
                                         height="60px"
                                         placeholder="제목을 입력해주세요"
@@ -232,14 +303,14 @@ const BoardCreate = () => {
                                         $borderRadius={5}
                                         ref={(el: never) => (inputRef.current[0] = el)}
                                         defaultValue={detail?.title}
-                                    ></TextInput>
+                                    ></ResponsiveTextInput>
                                 </Div>
-                            </Div>
+                            </FormSection>
 
                             {(url === "sponsor" || url === "usage") && (
-                                <Div width="100%" $padding="20px">
+                                <FormSection>
                                     <Div width="100%">
-                                        <DateInput
+                                        <ResponsiveDateInput
                                             width="100%"
                                             height="60px"
                                             fontSize="xl"
@@ -249,31 +320,30 @@ const BoardCreate = () => {
                                             defaultValue={detail?.dateHistory?.split("T")[0]}
                                         />
                                     </Div>
-                                </Div>
+                                </FormSection>
                             )}
 
-                            <Div width="100%" $padding="20px">
+                            <FormSection>
                                 <DragNDrop fileFetch menuId={currentMenuId} />
-                            </Div>
-                            <Div width="100%" $padding="20px">
+                            </FormSection>
+                            <FormSection>
                                 <TextEditor
                                     ref={(el: never) => (inputRef.current[1] = el)}
                                     initialContent={detail?.content}
                                 />
-                            </Div>
-                        </Div>
+                            </FormSection>
+                        </FormCard>
 
                         <FlexDiv width="100%" $margin="30px 0 0 0">
-                            <Button
+                            <SubmitButton
                                 $backgroundColor="bgColor"
                                 $HBackgroundColor="bgColorHo"
                                 $borderRadius={2}
                                 $padding="15px 30px"
-                                width="400px"
                                 onClick={() => sendInput()}
                             >
                                 {update === "create" ? <P color="wh">작성하기</P> : <P color="wh">수정하기</P>}
-                            </Button>
+                            </SubmitButton>
                         </FlexDiv>
                     </Div>
                 </Container>

--- a/src/pages/board/BoardDetail.tsx
+++ b/src/pages/board/BoardDetail.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { theme } from "../../styles/theme";
+import { media, theme } from "../../styles/theme";
 
 import { boardDetailData, tokenAccess } from "../../recoil/backState";
 import { carouselInitialState, carouselOpen } from "../../recoil/frontState";
@@ -33,8 +33,13 @@ import Loading from "../../components/common/Loading";
 import TextViewer from "../../components/common/TextViewer";
 
 const HorizonScrollDiv = styled(Div)`
+    max-width: 100%;
     white-space: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
 
     &::-webkit-scrollbar {
         display: block;
@@ -48,6 +53,88 @@ const HorizonScrollDiv = styled(Div)`
     /* 스크롤바 호버 스타일 추가 */
     &::-webkit-scrollbar-thumb:hover {
         background-color: ${(props) => props.theme.color.grey}; /* 스크롤바 썸의 호버 색상을 지정하세요 */
+    }
+`;
+
+const PostMeta = styled(FlexDiv)`
+    justify-content: flex-start;
+    row-gap: 8px;
+
+    ${media.mobile} {
+        align-items: flex-start;
+    }
+`;
+
+const MetaText = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+`;
+
+const PostTitle = styled(H2)`
+    overflow-wrap: anywhere;
+    word-break: break-word;
+
+    ${media.mobile} {
+        font-size: ${theme.fontSize.xl};
+        line-height: 1.4;
+    }
+`;
+
+const ContentArea = styled(Div)`
+    min-width: 0;
+    max-width: 100%;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+`;
+
+const AttachmentBox = styled(FlexDiv)`
+    width: 80%;
+    min-width: 0;
+    padding: 0 30px;
+    border: 2px solid ${theme.color.border};
+
+    ${media.mobile} {
+        width: 100%;
+        padding: 0 16px;
+    }
+`;
+
+const AttachmentRow = styled(FlexDiv)`
+    flex-wrap: nowrap;
+    min-width: 0;
+`;
+
+const FileNameContainer = styled(FlexDiv)`
+    min-width: 0;
+    flex: 1 1 auto;
+
+    > div {
+        width: 100%;
+        min-width: 0;
+        overflow: hidden;
+    }
+`;
+
+const FileName = styled(A)`
+    display: block;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const ActionRow = styled(FlexDiv)`
+    gap: 10px;
+
+    button {
+        margin: 0;
+        max-width: 100%;
+    }
+
+    ${media.mobile} {
+        justify-content: flex-start;
     }
 `;
 
@@ -253,54 +340,54 @@ const BoardDetail = () => {
                 <Carousel images={detail?.images?.map((image) => image.url) || []} />
             ) : (
                 <FlexDiv width="100%">
-                    <DetailContainer $alignitems="start">
+                    <DetailContainer $alignitems="start" $whiteSpace="normal">
                         <Div width="100%" $margin="0 0 30px 0">
-                            <FlexDiv $margin="50px 0 30px 0">
+                            <PostMeta $margin="50px 0 30px 0">
                                 <FlexDiv width="12px" $margin="0 5px 0 0">
                                     <Img src="/images/user_grey.svg" />
                                 </FlexDiv>
                                 <Div>
-                                    <P color="grey4" fontSize="sm">
+                                    <MetaText color="grey4" fontSize="sm">
                                         By {detail?.writerName} |
-                                    </P>
+                                    </MetaText>
                                 </Div>
                                 <FlexDiv width="12px" $margin="0 5px ">
                                     <Img src="/images/clock_grey.svg" />
                                 </FlexDiv>
                                 <Div>
-                                    <P color="grey4" fontSize="sm">
+                                    <MetaText color="grey4" fontSize="sm">
                                         {formatDateMinute({ date: detail?.dateCreated || "" })}
-                                    </P>
+                                    </MetaText>
                                 </Div>
-                            </FlexDiv>
-                            <Div>
-                                <H2 fontSize="xxl" fontWeight={800}>
+                            </PostMeta>
+                            <Div width="100%" $whiteSpace="normal">
+                                <PostTitle fontSize="xxl" fontWeight={800}>
                                     {detail?.title}
-                                </H2>
+                                </PostTitle>
                             </Div>
                             {["sponsor", "usage"].includes(url) && (
-                                <FlexDiv $margin="20px 0 30px 0">
+                                <PostMeta $margin="20px 0 30px 0">
                                     <FlexDiv width="12px" $margin="0">
                                         <Img src="/images/calendar_grey.svg" />
                                     </FlexDiv>
                                     <Div $margin="0 0 0 5px">
-                                        <P color="grey4" fontSize="sm">
+                                        <MetaText color="grey4" fontSize="sm">
                                             지급일 |
-                                        </P>
+                                        </MetaText>
                                     </Div>
                                     <FlexDiv width="12px" $margin="0 5px ">
                                         <Img src="/images/clock_grey.svg" />
                                     </FlexDiv>
                                     <Div>
-                                        <P color="grey4" fontSize="sm">
+                                        <MetaText color="grey4" fontSize="sm">
                                             {detail?.dateHistory?.split("T")[0] || ""}
-                                        </P>
+                                        </MetaText>
                                     </Div>
-                                </FlexDiv>
+                                </PostMeta>
                             )}
-                            <Div width="100%" $margin="50px 0" wrap="break-word" $whiteSpace="pre-wrap">
+                            <ContentArea width="100%" $margin="50px 0" $whiteSpace="pre-wrap">
                                 {detail?.content && <TextViewer contents={detail?.content} />}
-                            </Div>
+                            </ContentArea>
 
                             {detail && detail.images && detail.images.length > 0 && (
                                 <HorizonScrollDiv $margin="30px 0" width="100%">
@@ -322,10 +409,11 @@ const BoardDetail = () => {
 
                             <FlexDiv width="100%">
                                 {detail && detail.otherFiles && detail.otherFiles.length > 0 && (
-                                    <FlexDiv width="80%" $padding="0 30px" $border="2px solid" $borderColor="border">
+                                    <AttachmentBox $whiteSpace="normal">
                                         {detail.otherFiles.map((file, index) => (
-                                            <FlexDiv
+                                            <AttachmentRow
                                                 width="100%"
+                                                $whiteSpace="normal"
                                                 $justifycontent="start"
                                                 key={`otherFiles${index}`}
                                                 $borderB={
@@ -340,24 +428,28 @@ const BoardDetail = () => {
                                                         <Img src="/images/download_grey.svg" />
                                                     </Div>
                                                 </FlexDiv>
-                                                <FlexDiv $pointer>
-                                                    <Div onClick={() => onClickFileLink(file.url, file.name)}>
-                                                        <A
+                                                <FileNameContainer $pointer overflow="hidden">
+                                                    <Div
+                                                        width="100%"
+                                                        overflow="hidden"
+                                                        onClick={() => onClickFileLink(file.url, file.name)}
+                                                    >
+                                                        <FileName
                                                             color="textColor"
                                                             fontSize="sm"
                                                             fontWeight={700}
                                                             $hoverColor="bgColorHo"
                                                         >
                                                             {file.name}
-                                                        </A>
+                                                        </FileName>
                                                     </Div>
-                                                </FlexDiv>
-                                            </FlexDiv>
+                                                </FileNameContainer>
+                                            </AttachmentRow>
                                         ))}
-                                    </FlexDiv>
+                                    </AttachmentBox>
                                 )}
                             </FlexDiv>
-                            <FlexDiv $margin="50px 0 0 0" width="100%" $justifycontent="end">
+                            <ActionRow $margin="50px 0 0 0" width="100%" $justifycontent="end">
                                 {detail?.writerId === userId && (
                                     <Button
                                         display="flex"
@@ -397,7 +489,7 @@ const BoardDetail = () => {
                                         </Div>
                                     </Button>
                                 )}
-                            </FlexDiv>
+                            </ActionRow>
                         </Div>
                         {/* 공개자료실일 경우에 토큰 없이 댓글 패치 */}
                         {pathNameInfo[1] === "opensource" ? (

--- a/src/pages/board/BoardList.tsx
+++ b/src/pages/board/BoardList.tsx
@@ -30,10 +30,41 @@ import Pagination from "../../components/common/Pagination";
 import BoardNavigate from "../../components/board/BoardNavigate";
 import BoardSearch from "../../components/board/BoardSearch";
 import Contest from "../activity/Contest";
+import { media } from "../../styles/theme";
 
 const StickyDiv = styled(Div)`
     position: sticky;
     top: 50px;
+    flex: 0 0 auto;
+    width: 293px;
+
+    ${media.tablet} {
+        position: static;
+        top: auto;
+        width: 100%;
+        padding: 0;
+        margin-bottom: 30px;
+    }
+`;
+
+const BoardContainer = styled(Container)`
+    flex-wrap: nowrap;
+
+    ${media.tablet} {
+        flex-direction: column;
+    }
+`;
+
+const BoardContent = styled(Div)`
+    flex: 1 1 auto;
+    min-width: 0;
+    width: calc(100% - 293px);
+    padding: 0 15px;
+
+    ${media.tablet} {
+        width: 100%;
+        padding: 0;
+    }
 `;
 
 const BoardList = () => {
@@ -155,18 +186,18 @@ const BoardList = () => {
                     <Loading />
                 </FlexDiv>
             ) : (
-                <Container $alignitems="start">
+                <BoardContainer $alignitems="start">
                     <StickyDiv $padding="0 15px">
-                        <Div $margin="0 0 30px 0">
+                        <Div width="100%" $margin="0 0 30px 0">
                             <BoardSearch />
                         </Div>
                         {url !== "sponsor" && url !== "usage" && (
-                            <Div>
+                            <Div width="100%">
                                 <BoardNavigate />
                             </Div>
                         )}
                     </StickyDiv>
-                    <Div $padding="0 15px">
+                    <BoardContent>
                         <Suspense fallback={<Img src="/images/loading.svg" />}>
                             {["contest", "activity"].includes(url) ? (
                                 <Contest />
@@ -225,8 +256,8 @@ const BoardList = () => {
                                 size={4}
                             />
                         )}
-                    </Div>
-                </Container>
+                    </BoardContent>
+                </BoardContainer>
             )}
         </>
     );


### PR DESCRIPTION
## 개요

> 게시판 목록·상세·작성 화면과 관련 공통 콘텐츠 컴포넌트에 태블릿·모바일 반응형 스타일을 적용합니다. 기존 데스크톱 UI와 기능은 유지하고, `#619` 범위만 대응합니다.

## 변경 사항

- 게시판 네비게이션 반응형 레이아웃 적용
- 게시판 검색 반응형 레이아웃 적용
- NavigateTable 반응형 레이아웃 적용
- 게시판 목록 반응형 레이아웃 적용
- Carousel 반응형 레이아웃 적용
- 댓글 입력·목록 반응형 레이아웃 적용
- TextViewer 반응형 레이아웃 적용
- 게시글 상세 반응형 레이아웃 적용
- TextEditor·DragNDrop 반응형 레이아웃 적용
- 게시글 작성 반응형 레이아웃 적용

## 변경 유형

- [x] `feat` — 새로운 기능
- [ ] `fix` — 버그 수정
- [x] `design` — UI · 스타일 변경
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `docs` — 문서
- [ ] `chore` — 빌드 설정, 패키지 변경
- [ ] `ci` — CI/CD 설정 변경
- [ ] `revert` — 이전 커밋 되돌리기

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해 주세요 -->

resolves: #619

## 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before / After 스크린샷을 첨부해 주세요 -->

| Before | After |
|--------|-------|
|        |       |

## 체크리스트

- [x] `upstream/dev` 기준으로 브랜치를 만들었다
- [ ] 빌드가 정상적으로 된다 (`npm run build`)
- [ ] ESLint 에러가 없다
- [ ] 기존 기능이 정상 작동한다
- [x] WIP 커밋을 정리했다 (`git rebase -i`)
- [ ] 불필요한 `console.log`와 주석 처리된 코드를 제거했다