### PR TITLE
[fix/#572] 회장단 관리자페이지 버튼 노출 수정

### DIFF
--- a/src/containers/myInfo/MyInfoContainer.tsx
+++ b/src/containers/myInfo/MyInfoContainer.tsx
@@ -280,8 +280,7 @@ const MyInfoContainer = () => {
                             </FlexDiv>
 
                             <FlexDiv>
-                                {info?.role === "CHIEF" ||
-                                    (info?.role === "VICE_CHIEF" && (
+                                {(info?.role === "CHIEF" || info?.role === "VICE_CHIEF") && (
                                         <FlexDiv
                                             onClick={() => navigate("/staff/manage")}
                                             $minWidth={`${widthList[2]}px`}
@@ -290,7 +289,7 @@ const MyInfoContainer = () => {
                                         >
                                             <P color="textColor">관리자페이지</P>
                                         </FlexDiv>
-                                    ))}
+                                    )}
 
                                 {info?.type === "UNDERGRADUATE" && (
                                     <FlexDiv


### PR DESCRIPTION
## 개요

> 내 정보 화면의 관리자페이지 버튼이 연산자 우선순위 때문에 회장(CHIEF) 계정에서 노출되지 않던 문제를 수정합니다. 회장·부회장 모두 `/staff/manage`로 이동할 수 있습니다.

## 변경 사항

- 관리자페이지 버튼 조건을 `(CHIEF || VICE_CHIEF) && JSX`로 수정
- `/staff/manage` 이동 동작과 UI 스타일은 유지

## 변경 유형

- [ ] `feat` — 새로운 기능
- [x] `fix` — 버그 수정
- [ ] `design` — UI · 스타일 변경
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `docs` — 문서
- [ ] `chore` — 빌드 설정, 패키지 변경
- [ ] `ci` — CI/CD 설정 변경
- [ ] `revert` — 이전 커밋 되돌리기

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해 주세요 -->

resolves: #572

## 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before / After 스크린샷을 첨부해 주세요 -->

로그인 권한 테스트 환경이 없어 스크린샷은 첨부하지 못했습니다.

| Before | After |
|--------|-------|
| CHIEF 계정에서 버튼 미노출 | CHIEF·VICE_CHIEF 계정에서 버튼 노출 |

## 체크리스트

- [x] `upstream/dev` 기준으로 브랜치를 만들었다
- [x] 빌드가 정상적으로 된다 (`npm run build`)
- [ ] ESLint 에러가 없다
- [ ] 기존 기능이 정상 작동한다
- [x] WIP 커밋을 정리했다 (`git rebase -i`)
- [x] 불필요한 `console.log`와 주석 처리된 코드를 제거했다