### PR TITLE
[feat/#573] 신입부원 모집 일정 메인 안내 추가

### DIFF
--- a/src/components/common/modal/ModalMajor.tsx
+++ b/src/components/common/modal/ModalMajor.tsx
@@ -9,7 +9,6 @@ import useFetch from "../../../hooks/useFetch";
 import { majorInfo } from "../../../recoil/backState";
 import { majorSelected, modalInfo, modalOpen, refetch } from "../../../recoil/frontState";
 
-import A from "../../../styles/assets/A";
 import Button from "../../../styles/assets/Button";
 import { Div, FlexDiv } from "../../../styles/assets/Div";
 import { H2 } from "../../../styles/assets/H";
@@ -17,36 +16,54 @@ import Img from "../../../styles/assets/Img";
 import { TextInput } from "../../../styles/assets/Input";
 import P from "../../../styles/assets/P";
 
-const TableHover = styled(FlexDiv)`
+const MajorTableRow = styled.div<{ $selected?: boolean; $pointer?: boolean }>`
+    display: grid;
+    grid-template-columns: 150px minmax(270px, 1fr) 160px;
+    align-items: center;
+    width: 100%;
+    min-width: 580px;
+    min-height: 45px;
+    background-color: ${({ $selected }) => ($selected ? theme.color.tableHo : theme.color.wh)};
+    border-top: 1px solid ${theme.color.grey1};
+    cursor: ${({ $pointer }) => ($pointer ? "pointer" : "default")};
+
     &:hover {
         background-color: ${theme.color.tableHo};
     }
 `;
 
+const MajorTableHeader = styled(MajorTableRow)`
+    border-top: 0;
+    border-bottom: 1px solid ${theme.color.tableBorder};
+`;
+
+const MajorTableCell = styled.div`
+    min-width: 0;
+    padding: 10px;
+`;
+
+const MajorTableText = styled(P)`
+    white-space: nowrap;
+`;
+
 const MajorTableScroll = styled.div`
     width: 100%;
     max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 
     ${media.mobile} {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
+        margin: 0 -4px;
+        width: calc(100% + 8px);
     }
 `;
 
 const MajorTable = styled(Div)`
-    ${media.mobile} {
-        width: 580px;
-
-        > div {
-            flex-wrap: nowrap;
-        }
-    }
+    min-width: 580px;
 `;
 
 const MajorList = styled(Div)`
-    ${media.mobile} {
-        height: 220px !important;
-    }
+    height: 170px !important;
 `;
 
 interface MajorItem {
@@ -62,8 +79,7 @@ const ModalMajor = () => {
         setOpen(false);
     };
 
-    const headerInfo = ["학교명", "단과대학", "학과명"];
-    const widthList = [150, 160, 270];
+    const headerInfo = ["학교명", "학과명", "단과대학"];
 
     const modalType = useRecoilValue(modalInfo);
     const [data, fetchData] = useFetch();
@@ -174,45 +190,33 @@ const ModalMajor = () => {
                     <>
                         <MajorTableScroll>
                             <MajorTable width="100%">
-                                <FlexDiv
-                                    width="100%"
-                                    height="45px"
-                                    $borderB={`1px solid ${theme.color.tableBorder}`}
-                                    $justifycontent="space-between"
-                                >
-                                    {headerInfo.map((item: string, idx: number) => (
-                                        <FlexDiv key={`headerInfo${idx}`} $minWidth={`${widthList[idx]}px`} $padding="10px">
-                                            <P $center fontWeight={700}>
+                                <MajorTableHeader>
+                                    {headerInfo.map((item: string) => (
+                                        <MajorTableCell key={item}>
+                                            <MajorTableText $center fontWeight={700}>
                                                 {item}
-                                            </P>
-                                        </FlexDiv>
+                                            </MajorTableText>
+                                        </MajorTableCell>
                                     ))}
-                                </FlexDiv>
+                                </MajorTableHeader>
                                 <MajorList width="100%" height="60%" overflow="auto">
                                     {filteredResults.map((element: { college: string; major: string }, idx: number) => (
-                                        <TableHover
+                                        <MajorTableRow
                                             key={`contentItem${idx}`}
-                                            width="100%"
-                                            height="45px"
-                                            $borderT={`1px solid ${theme.color.grey1}`}
-                                            $justifycontent="space-between"
-                                            $backgroundColor={selectedTable.major === element.major ? "tableHo" : "wh"}
+                                            $selected={selectedTable.major === element.major}
                                             $pointer
                                             onClick={() => chooseMajor(element)}
                                         >
-                                            <FlexDiv $padding="10px" $minWidth={`${widthList[0]}px`}>
-                                                <A $center>인하대학교</A>
-                                            </FlexDiv>
-                                            {Object.values(element).map((item: any, idx: number) => (
-                                                <FlexDiv
-                                                    key={`itemValue${idx}`}
-                                                    $minWidth={`${widthList[idx + 1]}px`}
-                                                    $padding="10px"
-                                                >
-                                                    <A $center>{item}</A>
-                                                </FlexDiv>
-                                            ))}
-                                        </TableHover>
+                                            <MajorTableCell>
+                                                <MajorTableText $center>인하대학교</MajorTableText>
+                                            </MajorTableCell>
+                                            <MajorTableCell>
+                                                <MajorTableText $center>{element.major}</MajorTableText>
+                                            </MajorTableCell>
+                                            <MajorTableCell>
+                                                <MajorTableText $center>{element.college}</MajorTableText>
+                                            </MajorTableCell>
+                                        </MajorTableRow>
                                     ))}
                                 </MajorList>
                             </MajorTable>

--- a/src/components/home/RecruitmentScheduleNotice.tsx
+++ b/src/components/home/RecruitmentScheduleNotice.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+import { scheduleInterface } from "../../types/ibas/TypeMyinfo";
+import { media, theme } from "../../styles/theme";
+
+type RecruitmentSchedule = Pick<scheduleInterface, "signupStartDate" | "signupEndDate">;
+
+const NoticeBackground = styled.div`
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background-color: rgba(0, 0, 0, 0.5);
+
+    ${media.mobile} {
+        padding: 16px;
+    }
+`;
+
+const Notice = styled.aside`
+    width: min(440px, 100%);
+    padding: 20px;
+    border: 1px solid ${theme.color.bgColor};
+    border-radius: 8px;
+    background-color: ${theme.color.wh};
+    box-shadow: 0 12px 30px rgba(36, 34, 48, 0.2);
+
+    ${media.mobile} {
+        padding: 16px;
+    }
+`;
+
+const NoticeHeader = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+`;
+
+const NoticeTitle = styled.h2`
+    margin: 0;
+    color: ${theme.color.textColor};
+    font-size: ${theme.fontSize.lg};
+    font-weight: 700;
+`;
+
+const NoticeDescription = styled.p`
+    margin: 14px 0 6px;
+    color: ${theme.color.bk};
+    font-size: ${theme.fontSize.md};
+    font-weight: 500;
+    line-height: 1.5;
+`;
+
+const NoticePeriod = styled.p`
+    margin: 0;
+    color: ${theme.color.grey};
+    font-size: ${theme.fontSize.sm};
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+`;
+
+const NoticeActions = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 20px;
+
+    ${media.mobile} {
+        flex-direction: column;
+    }
+`;
+
+const ActionButton = styled.button<{ $primary?: boolean }>`
+    min-height: 40px;
+    padding: 10px 14px;
+    border: 1px solid ${({ $primary }) => ($primary ? theme.color.bgColor : theme.color.grey2)};
+    border-radius: 4px;
+    background-color: ${({ $primary }) => ($primary ? theme.color.bgColor : theme.color.wh)};
+    color: ${({ $primary }) => ($primary ? theme.color.wh : theme.color.grey)};
+    font-size: ${theme.fontSize.sm};
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover {
+        background-color: ${({ $primary }) => ($primary ? theme.color.bgColorHo : theme.color.border)};
+    }
+
+    &:focus-visible {
+        outline: 2px solid ${theme.color.bgColor};
+        outline-offset: 2px;
+    }
+`;
+
+const RECRUITMENT_NOTICE_DISMISS_UNTIL_KEY = "ibas-recruitment-notice-dismiss-until";
+
+const isRecruitmentSchedule = (data: unknown): data is RecruitmentSchedule => {
+    if (!data || typeof data !== "object") {
+        return false;
+    }
+
+    const schedule = data as RecruitmentSchedule;
+    return typeof schedule.signupStartDate === "string" && typeof schedule.signupEndDate === "string";
+};
+
+const isRecruitmentPeriod = (schedule: RecruitmentSchedule, now = new Date()) => {
+    const signupStartDate = new Date(schedule.signupStartDate);
+    const signupEndDate = new Date(schedule.signupEndDate);
+
+    if (Number.isNaN(signupStartDate.getTime()) || Number.isNaN(signupEndDate.getTime())) {
+        return false;
+    }
+
+    return signupStartDate <= now && now <= signupEndDate;
+};
+
+const formatDate = (date: string) => {
+    const value = new Date(date);
+
+    if (Number.isNaN(value.getTime())) {
+        return "";
+    }
+
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const day = String(value.getDate()).padStart(2, "0");
+    const hours = String(value.getHours()).padStart(2, "0");
+    const minutes = String(value.getMinutes()).padStart(2, "0");
+
+    return `${year}.${month}.${day} ${hours}:${minutes}`;
+};
+
+const isDismissedForToday = (now: Date) => {
+    try {
+        const dismissUntil = localStorage.getItem(RECRUITMENT_NOTICE_DISMISS_UNTIL_KEY);
+        return dismissUntil !== null && now.getTime() < new Date(dismissUntil).getTime();
+    } catch {
+        return false;
+    }
+};
+
+const dismissUntilTomorrow = (now: Date) => {
+    const tomorrow = new Date(now);
+    tomorrow.setHours(24, 0, 0, 0);
+
+    try {
+        localStorage.setItem(RECRUITMENT_NOTICE_DISMISS_UNTIL_KEY, tomorrow.toISOString());
+    } catch {
+        // 브라우저 저장소를 사용할 수 없어도 현재 방문에서는 모달을 닫는다.
+    }
+};
+
+const RecruitmentScheduleNotice = () => {
+    const [schedule, setSchedule] = useState<RecruitmentSchedule | null>(null);
+    const [isClosed, setIsClosed] = useState(false);
+    const [currentTime, setCurrentTime] = useState(() => new Date());
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const fetchSchedule = async () => {
+            if (isDismissedForToday(currentTime)) {
+                return;
+            }
+
+            try {
+                const response = await fetch(`${import.meta.env.VITE_API_URL}/signUp/schedule`);
+
+                if (!response.ok) {
+                    return;
+                }
+
+                const data: unknown = await response.json();
+                if (isMounted && isRecruitmentSchedule(data) && isRecruitmentPeriod(data)) {
+                    setSchedule(data);
+                }
+            } catch {
+                // 일정 조회에 실패하면 메인 화면에는 별도 안내를 표시하지 않는다.
+            }
+        };
+
+        fetchSchedule();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [currentTime]);
+
+    useEffect(() => {
+        if (!schedule) {
+            return;
+        }
+
+        const signupEndDate = new Date(schedule.signupEndDate);
+        const remainingTime = signupEndDate.getTime() - currentTime.getTime() + 1;
+        const timeout = window.setTimeout(
+            () => setCurrentTime(new Date()),
+            Math.min(Math.max(remainingTime, 1), 2_147_483_647)
+        );
+
+        return () => window.clearTimeout(timeout);
+    }, [schedule, currentTime]);
+
+    if (!schedule || isClosed || !isRecruitmentPeriod(schedule, currentTime)) {
+        return null;
+    }
+
+    return (
+        <NoticeBackground>
+            <Notice role="dialog" aria-modal="true" aria-labelledby="recruitment-notice-title">
+                <NoticeHeader>
+                    <NoticeTitle id="recruitment-notice-title">신입부원 모집 중</NoticeTitle>
+                </NoticeHeader>
+                <NoticeDescription>IBAS 신입부원을 모집하고 있습니다.</NoticeDescription>
+                <NoticePeriod>
+                    모집 기간: {formatDate(schedule.signupStartDate)} ~ {formatDate(schedule.signupEndDate)}
+                </NoticePeriod>
+                <NoticeActions>
+                    <ActionButton type="button" onClick={() => setIsClosed(true)}>
+                        닫기
+                    </ActionButton>
+                    <ActionButton
+                        type="button"
+                        $primary
+                        onClick={() => {
+                            dismissUntilTomorrow(currentTime);
+                            setIsClosed(true);
+                        }}
+                    >
+                        오늘 하루 다시 보지 않기
+                    </ActionButton>
+                </NoticeActions>
+            </Notice>
+        </NoticeBackground>
+    );
+};
+
+export default RecruitmentScheduleNotice;

--- a/src/pages/home/Main.tsx
+++ b/src/pages/home/Main.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { relogin } from "../../recoil/frontState";
 
+import RecruitmentScheduleNotice from "../../components/home/RecruitmentScheduleNotice";
 import { Div, FlexDiv } from "../../styles/assets/Div";
 import Img from "../../styles/assets/Img";
 import { media } from "../../styles/theme";
@@ -88,6 +89,7 @@ const Main = () => {
     return (
         <>
             <MainDiv width="100%" height="100vh" direction="column">
+                {import.meta.env.DEV && <RecruitmentScheduleNotice />}
                 <MainContent direction="column" width="100%" height="90%">
                     <Logo width="350px" height="350px">
                         <LogoImg src="/images/ibas-main-logo_white.png" />

--- a/src/pages/member/SignupQuestion.tsx
+++ b/src/pages/member/SignupQuestion.tsx
@@ -62,6 +62,13 @@ const QuestionList = styled(FlexDiv)`
     }
 `;
 
+const QuestionTitle = styled(P).attrs({ $whiteSpace: "normal" })`
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.5;
+`;
+
 const QuestionActions = styled(FlexDiv)`
     ${media.mobile} {
         gap: 12px;
@@ -235,7 +242,7 @@ const SignupQuestion = () => {
                                             $margin={idx === 0 ? "0" : "30px 0 0 0"}
                                             key={`question${idx}`}
                                         >
-                                            <P fontWeight={700}> {item.question}</P>
+                                            <QuestionTitle fontWeight={700}>{item.question}</QuestionTitle>
                                             <TextArea
                                                 defaultValue={(answer && answer[idx]?.content) || ""}
                                                 ref={(el: never) => (ref.current[idx] = el)}


### PR DESCRIPTION
## 개요

> 회장이 설정한 신입부원 모집 기간 동안 메인 페이지에서 모집 안내를 표시합니다. `#573` 범위에 맞춰 모집 일정 조회·안내 UI를 추가하고, 관련 화면 레이아웃을 함께 수정합니다.

## 변경 사항

- `RecruitmentScheduleNotice` 컴포넌트 추가: `/signUp/schedule` 조회 후 모집 기간 내 안내 모달 표시
- 메인 페이지에 신입부원 모집 안내 컴포넌트 연동 (현재 개발 환경에서만 노출)
- 모집 안내 닫기·오늘 하루 다시 보지 않기(localStorage) 동작 추가
- `ModalMajor` 학과 선택 테이블 레이아웃 개선 (grid 기반 정렬, 컬럼 순서 정리)
- 회원가입 질문 화면 문항 텍스트 줄바꿈 레이아웃 수정

## 변경 유형

- [x] `feat` — 새로운 기능
- [x] `fix` — 버그 수정
- [x] `design` — UI · 스타일 변경
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `docs` — 문서
- [ ] `chore` — 빌드 설정, 패키지 변경
- [ ] `ci` — CI/CD 설정 변경
- [ ] `revert` — 이전 커밋 되돌리기

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해 주세요 -->

resolves: #573

## 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before / After 스크린샷을 첨부해 주세요 -->

| Before | After |
|--------|-------|
|        |       |

## 체크리스트

- [x] `upstream/dev` 기준으로 브랜치를 만들었다
- [ ] 빌드가 정상적으로 된다 (`npm run build`)
- [ ] ESLint 에러가 없다
- [ ] 기존 기능이 정상 작동한다
- [x] WIP 커밋을 정리했다 (`git rebase -i`)
- [x] 불필요한 `console.log`와 주석 처리된 코드를 제거했다